### PR TITLE
No more default CVSS value when no CVSS are set for a CVE.

### DIFF
--- a/sbin/db_mgmt.py
+++ b/sbin/db_mgmt.py
@@ -244,7 +244,7 @@ if __name__ == '__main__':
                 if args.v:
                     print("item found : " + item['id'])
                 if 'cvss' not in item:
-                    item['cvss'] = defaultvalue['cvss']
+                    item['cvss'] = None
                 else:
                     item['cvss'] = float(item['cvss'])
                 if 'cwe' not in item:


### PR DESCRIPTION
This should fix #93.

As the default CVSS feature seems not to be used, it will be removed
too.