### PR TITLE
Fix #97 - get index path from Configuration

### DIFF
--- a/bin/search_fulltext.py
+++ b/bin/search_fulltext.py
@@ -8,7 +8,6 @@
 # Copyright (c) 2012-2015 	Alexandre Dulaunoy - a@foo.be
 # Copyright (c) 2015 		Pieter-Jan Moreels - pieterjan.moreels@gmail.com
 
-# Imports
 import os
 
 from whoosh import index
@@ -21,8 +20,11 @@ import json
 from bson import json_util
 
 runPath = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(runPath, ".."))
+from lib.Config import Configuration
 
-indexpath = "./indexdir"
+indexpath = Configuration.getIndexdir()
+
 schema = Schema(title=TEXT(stored=True), path=ID(stored=True), content=TEXT)
 
 ix = index.open_dir("indexdir")


### PR DESCRIPTION
fulltext search client didn't use the configuration parameters
to get the index path. This is now fixed.