### PR TITLE
Handle exploit definition without ref element to fix #129

### DIFF
--- a/sbin/db_mgmt_d2sec.py
+++ b/sbin/db_mgmt_d2sec.py
@@ -58,8 +58,9 @@ class ExploitHandler(ContentHandler):
                 if self.reftype == 'CVE':
                     self.refcvetag = True
                     self.cveref = ""
-                elif self.reftype != 'CVE':
+                elif self.reftype != 'CVE' :
                     self.refcvetag = False
+                    self.cveref = False
 
     def characters(self, ch):
         if self.nametag:
@@ -71,7 +72,7 @@ class ExploitHandler(ContentHandler):
 
     def endElement(self, name):
         if name == 'ref':
-            if self.cveref != "":
+            if self.cveref != "" and self.cveref:
                 self.refl.append(self.cveref.rstrip())
             self.reftag = False
         if name == 'name':


### PR DESCRIPTION
XML document of d2sec can have exploit without any reference.