### PR TITLE
Fix bug in CPE parsing

### DIFF
--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -59,7 +59,7 @@ class CPEHandler(ContentHandler):
             self.title += ch
 
     def endElement(self, name):
-        if name == 'cpe-item':
+        if name == 'title':
             self.titletag = False
             self.cpe[-1]['title'].append(self.title.rstrip())
         elif name == 'references':


### PR DESCRIPTION
The current CPE dictionary parsing didn't catch the end of the 'title'
tag and would have extra data in the 'title' attribute of the CPE.

As an example using CVE-2015-7183 from
https://cve.circl.lu/api/cve/CVE-2015-7183:

Currently shows up like this:
```
    {
      "id": "cpe:2.3:a:mozilla:firefox:41.0.2",
      "title": "Mozilla Firefox 41.0.2\n    \n      Vendor"
    },
```

Should be:
```
    {
      "id": "cpe:2.3:a:mozilla:firefox:41.0.2",
      "title": "Mozilla Firefox 41.0.2"
    },
```

This closes #160 