### PR TITLE
fix(README): examlary calls were broken, i.e. were prefixed by `./python3.3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,11 @@ or department within your organization or any meaningful name for you.
 As an example, you can add a partial CPE name like "sap:netweaver" which is very
 critical for your accounting department.
 
-    ./python3.3 sbin/db_ranking.py  -c "sap:netweaver" -g "accounting" -r 3
+    ./sbin/db_ranking.py  -c "sap:netweaver" -g "accounting" -r 3
 
 and then you can lookup the ranking (-r option) for a specific CVE-ID:
 
-    ./python3.3 bin/search.py -c CVE-2012-4341  -r  -n
+    ./bin/search.py -c CVE-2012-4341  -r  -n
 
 Advanced usage
 --------------
@@ -192,15 +192,15 @@ Fulltext indexing
 
 If you want to index all the CVEs from your current MongoDB collection:
 
-    ./python3.3 sbin/db_fulltext.py
+    ./sbin/db_fulltext.py
 
 and you query the fulltext index (to get a list of matching CVE-ID):
 
-    ./python3.3 bin/search_fulltext.py -q NFS -q Linux
+    ./bin/search_fulltext.py -q NFS -q Linux
 
 or to query the fulltext index and output the JSON object for each CVE-ID:
 
-    ./python3.3 bin/search_fulltext.py -q NFS -q Linux -j
+    ./bin/search_fulltext.py -q NFS -q Linux -j
 
 Fulltext visualization
 ----------------------
@@ -211,7 +211,7 @@ required to generate the keywords with the most common English
 stopwords and lemmatize the output. [NTLK for Python 3](http://nltk.org/nltk3-alpha/)
 exists but you need to use the alpha version of NLTK.
 
-    ./python3.3 bin/search_fulltext.py  -g -s >cve.json
+    ./bin/search_fulltext.py  -g -s >cve.json
 
 ![cve-search visualization](https://farm9.staticflickr.com/8109/8603509755_c7690c2de4_n.jpg "CVE Keywords Visualization Using Data From cve-search")
 
@@ -225,7 +225,7 @@ query a specific CVE. You'll need flask in order to run the website and [Flask-P
 the web interface:
 
     cd ./web
-    ./python3.3 index.py
+    ./index.py
 
 Then you can connect on http://127.0.0.1:5000/ to browser the last CVE.
 


### PR DESCRIPTION
this constraint on the location of the `python3.3` executable is in general not satisfied.