### PR TITLE
Plugins global config and its parsing

### DIFF
--- a/etc/plugins.txt.sample
+++ b/etc/plugins.txt.sample
@@ -1,2 +1,13 @@
-# Plugin Location		load/default/pass
-# path/to/plugin		setting
+# Syntax:
+# path/to/plugin                either 'load', 'default', or 'pass'
+#
+# path/to/plugin = relative to cve-search root dir, path to plugin code directory
+# Ex: 'foo' plugin installed in cve-search/ with 'plugins/foo/plugins/foo.py',
+# then path is 'plugins/foo/plugins'
+#
+# pass = do not load the plugin
+# default = load the plugin
+# load = for a configurable plugin, use its config setup file
+#
+# Complete example for the 'seen' plugin:
+# plugins/seen/plugins/seen     load

--- a/lib/PluginManager.py
+++ b/lib/PluginManager.py
@@ -30,8 +30,7 @@ class PluginManager():
         return
     # Read and parse plugin file
     data = open(conf.getPluginLoadSettings(), "r").read()
-    data = [x.split("\t") for x in data.split("\n") if not x.startswith("#") and x]
-    data = [[x.strip() for x in y if x.strip()] for y in data]
+    data = [x.split() for x in data.splitlines() if not x.startswith("#")]
     for x in [x for x in data if len(x) == 2]:
       try:
         if x[1].lower() == "load" or x[1].lower() == "default":


### PR DESCRIPTION
PluginManager:
- split by words with with spaces removal instead of tab, thus handling spaces as well + no need for `strip()`
- use portable `splitlines()` rather than split on '\n'

With this combination, trying 0 bytes file, empty lines, mix of space and/or tabs anywhere, I could not get this to break with or without the final `and x` in `if not x.startswith("#") and x`, so removed.

**Motivation:  idiot-proof sample config + improve user-friendliness of PluginManager config handling**

The storytelling:

I played with plugins. First reading, later re-reading the doc, and it ended up taking me much more time than I expected.

My root issue was that I simply used _spaces_ in my `etc/plugins.txt`, instead of _tabs_, resulting in all my plugin config lines being ignored. Before digging into the code, this led me to tweak the config in many messy ways, with such questions as:
- Isn't the plugin location the root dir of the plugin (e.g. `plugins/seen/`)? or an URL relative to web server (seems weird)? (neither of these)
- If the plugin takes a configuration file, should I put it in `cve-search/etc/`, renamed according to plugin name, and/or pass its full path after the `load` in `plugins.txt`? (neither, again)
- ...or does this `load` takes a wished web server URL as parameter (weird, again, of course)?

etc.

(I now have the 'bookmarks', 'seen', and 'notes' running, and 'reporting' and 'collaboration' visible but untested yet.)
