### PR TITLE
Variable name should be errors in /r/<int:r>

### DIFF
--- a/web/index.py
+++ b/web/index.py
@@ -277,7 +277,7 @@ def filterPost():
 def filterLast(r):
     if not r:
         r = 0
-    settings,cve,error = getFilterSettingsFromPost(r)
+    settings,cve,errors = getFilterSettingsFromPost(r)
     return render_template('index.html', settings=settings, cve=cve, r=r, pageLength=pageLength,
                            filters=plugManager.getFilters(**pluginArgs()), errors=errors)
 


### PR DESCRIPTION
When browsing the UI, this would trigger an 500 Error 

function is expecting errors, not error

> Traceback (most recent call last):
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 2000, in __call__
>     return self.wsgi_app(environ, start_response)
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1991, in wsgi_app
>     response = self.make_response(self.handle_exception(e))
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1567, in handle_exception
>     reraise(exc_type, exc_value, tb)
>   File "/usr/local/lib/python3.4/dist-packages/flask/_compat.py", line 33, in reraise
>     raise value
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1988, in wsgi_app
>     response = self.full_dispatch_request()
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1641, in full_dispatch_request
>     rv = self.handle_user_exception(e)
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1544, in handle_user_exception
>     reraise(exc_type, exc_value, tb)
>   File "/usr/local/lib/python3.4/dist-packages/flask/_compat.py", line 33, in reraise
>     raise value
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1639, in full_dispatch_request
>     rv = self.dispatch_request()
>   File "/usr/local/lib/python3.4/dist-packages/flask/app.py", line 1625, in dispatch_request
>     return self.view_functions[rule.endpoint](**req.view_args)
>   File "/opt/be-cve-search/web/index.py", line 283, in filterLast
>     filters=plugManager.getFilters(**pluginArgs()), errors=errors)
> NameError: name 'errors' is not defined