### PR TITLE
Fix UTF-8 encoding issue when parsing CWE and ExploitDB Files

### DIFF
--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -100,7 +100,7 @@ cwezip.close()
 with zipfile.ZipFile(tmpfile.name) as z:
     z.extractall(tmpdir)
     z.close()
-f = open(os.path.join(tmpdir, 'cwec_v2.8.xml'))
+f = open(os.path.join(tmpdir, 'cwec_v2.8.xml'), encoding='utf-8')
 # parse xml and store in database
 parser.parse(f)
 cweList=[]

--- a/sbin/db_mgmt_exploitdb.py
+++ b/sbin/db_mgmt_exploitdb.py
@@ -50,7 +50,7 @@ with open(csvfile, 'wb') as fp:
 fp.close()
 
 exploits=[]
-with open(csvfile, newline='') as csvtoparse:
+with open(csvfile, newline='', encoding='utf-8') as csvtoparse:
     exploitcsv = csv.DictReader(csvtoparse, delimiter=',')
     for row in exploitcsv:
         exploits.append(row)


### PR DESCRIPTION
Hi,
i got some UTF-8 encoding issue  when running an update ./sbin/db_updater.py   -v ,
CWE and ExploitDB Files contains some utf-8 characters, 

Here is the output : 

_Starting cwe
Traceback (most recent call last):
  File "/root/cve-search.orig/sbin/db_mgmt_cwe.py", line 103, in <module>
    parser.parse(f)
  File "/usr/lib64/python3.4/xml/sax/expatreader.py", line 107, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib64/python3.4/xml/sax/xmlreader.py", line 124, in parse
    buffer = file.read(self._bufsize)
  File "/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 46797: ordinal not in range(128)
cwe has 0 elements (0 update)_

_Traceback (most recent call last):
  File "/root/cve-search.orig/sbin/db_mgmt_exploitdb.py", line 55, in <module>
    for row in exploitcsv:
  File "/usr/lib64/python3.4/csv.py", line 110, in __next__
    row = next(self.reader)
  File "/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2736: ordinal not in range(128)
exploitdb has 0 elements (0 update)_

The change made in the pull request fix theses.