### PR TITLE
Remove .gz from vendor url

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -45,7 +45,7 @@ class Configuration():
                'cpedict': "https://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml",
                'cwedict': "http://cwe.mitre.org/data/xml/cwec_v2.8.xml.zip",
                'd2sec': "http://www.d2sec.com/exploits/elliot.xml",
-               'vendor': "https://nvd.nist.gov/download/vendorstatements.xml.gz",
+               'vendor': "https://nvd.nist.gov/download/vendorstatements.xml",
                'capec': "http://capec.mitre.org/data/xml/capec_v2.6.xml",
                'msbulletin': "http://download.microsoft.com/download/6/7/3/673E4349-1CA5-40B9-8879-095C72D5B49D/BulletinSearch.xlsx",
                'ref': "https://cve.mitre.org/data/refs/refmap/allrefmaps.zip",


### PR DESCRIPTION
To avoid the following issue : 

Cannot open url https://nvd.nist.gov/download/vendorstatements.xml.gz. Bad URL or not connected to the internet?

remove .gz from vendor url  as getFile function add the extension .gz when call with compressed parameter set to True, so cve-search was trying to get file from url : https://nvd.nist.gov/download/vendorstatements.xml.gz.gz
