### PR TITLE
Simplify places to fetch sources in install doc

### DIFF
--- a/doc/html/Installation.html
+++ b/doc/html/Installation.html
@@ -54,21 +54,13 @@
   </p>
   <h2>Setting up CVE-Search</h2>
   <p>
-    Before setting up CVE-Search, you have to make sure the scripts are present on your system. Your best choice is to use <span class="code">git</span> to clone CVE-Search from github.
-    You can clone either of the git projects found below
-    <ul>
-      <li><span class="code">git clone https://github.com/PidgeyL/cve-search.git</span></li>
-      <li><span class="code">git clone https://github.com/adulau/cve-search.git</span></li>
-      <li><span class="code">git clone https://github.com/cve-search/cve-search.git</span></li>
-    </ul>
-    Other sources are available, but most of them are either outdated or experimental. <br />
+    Before setting up CVE-Search, you have to make sure the scripts are present on your system. Your best choice is to use <span class="code">git</span> 
+    to clone CVE-Search from its github repository:
     <br />
-    Alternatively, you can download the project by downloading the zip file and extracting it. You can get the zip file from the following places:
-    <ul>
-      <li><a href="https://github.com/PidgeyL/cve-search/archive/master.zip">PidgeyLs fork</a></li>
-      <li><a href="https://github.com/adulau/cve-search/archive/master.zip">Alexandre Dulaunoys fork</a></li>
-      <li><a href="https://github.com/cve-search/cve-search/archive/master.zip">The offical CVE-Search Project, based of Wim Remes work</a></li>
-    </ul>
+      <span class="code">git clone https://github.com/cve-search/cve-search.git</span>
+    <br />
+    Alternatively, you can download the project zip file and extracting it from <a href="https://github.com/cve-search/cve-search/archive/master.zip">the offical CVE-Search Project, based of Wim Remes work</a>
+    <br />
     The initial setup of CVE-Search happens only once, at the installation. This consists of three steps and one optional step.
     <ol>
       <li>Populating the database</li>


### PR DESCRIPTION
* List only cve-search as the place to fetch sources
* Other forks do not seem entirely up to date