### PR TITLE
refactoring of displaying functions and usage of them in cveid search mode (-c)

### DIFF
--- a/bin/search.py
+++ b/bin/search.py
@@ -94,7 +94,7 @@ if sLatest:
     sorttype = -1
 
 
-def printCVE(item, indent=None):
+def printCVE_json(item, indent=None):
     date_fields = ['cvss-time', 'Modified', 'Published']
     for field in date_fields:
         if field in item:
@@ -121,16 +121,98 @@ def printCVE(item, indent=None):
                     item['capec'] = cves.getcapec(cweid=(item['cwe'].split('-')[1]))
             print(json.dumps(item, sort_keys=True, default=json_util.default, indent=indent))
 
+def printCVE_html(item):
+    print("<h2>" + item['id'] + "<br></h2>CVSS score: " + str(item['cvss']) + "<br>" + "<b>" + str(item['Published']) + "<b><br>" + item['summary'] + "<br>")
+    print("References:<br>")
+    for entry in item['references']:
+        print(entry + "<br>")
+    print("<hr><hr>")
+
+def printCVE_csv(item):
+    # We assume that the vendor name is usually in the hostame of the
+    # URL to avoid any match on the resource part
+    refs = []
+    for entry in item['references']:
+        if args.v is not None:
+            url = urlparse(entry)
+            hostname = url.netloc
+            if re.search(args.v, hostname):
+                refs.append(entry)
+    if not refs:
+        refs = "[no vendor link found]"
+    if namelookup:
+        nl = " ".join(item['vulnerable_configuration'])
+    csvoutput = csv.writer(sys.stdout, delimiter='|', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+    if not namelookup:
+        csvoutput.writerow([item['id'], str(item['Published']), item['cvss'], item['summary'], refs])
+    else:
+        csvoutput.writerow([item['id'], str(item['Published']), item['cvss'], item['summary'], refs, nl])
+
+def printCVE_xml(item):
+    c = SubElement(r, 'id')
+    c.text = item['id']
+    c = SubElement(r, 'Published')
+    c.text = str(item['Published'])
+    c = SubElement(r, 'cvss')
+    c.text = str(item['cvss'])
+    c = SubElement(r, 'summary')
+    c.text = SaxEscape(item['summary'])
+    for e in item['references']:
+        c = SubElement(r, 'references')
+        c.text = SaxEscape(e)
+    for e in item['vulnerable_configuration']:
+        c = SubElement(r, 'vulnerable_configuration')
+        c.text = SaxEscape(e)
+
+def printCVE_id(item):
+    print(item['id'])
+
+def printCVE_human(item):
+    print("CVE\t: " + item['id'])
+    print("DATE\t: " + str(item['Published']))
+    print("CVSS\t: " + str(item['cvss']))
+    print(item['summary'])
+    print("\nReferences:")
+    print("-----------")
+    for entry in item['references']:
+        print(entry)
+    print("\nVulnerable Configs:")
+    print("-------------------")
+    for entry in item['vulnerable_configuration']:
+        if not namelookup:
+            print(entry)
+        else:
+            print(cves.getcpe(cpeid=entry))
+    print("\n\n")
+
+
 if cveSearch:
-    for cveid in db.getCVEs(cves=cveSearch):
-        printCVE(cveid)
+    for item in db.getCVEs(cves=cveSearch):
+        if csvOutput:
+            printCVE_csv(item)
+        elif htmlOutput:
+            printCVE_html(item)
+        # bson straight from the MongoDB db - converted to JSON default
+        # representation
+        elif jsonOutput:
+            printCVE_json(item)
+        elif xmlOutput:
+            printCVE_xml(item)
+        elif cveidOutput:
+            printCVE_id(item)
+        else:
+            printCVE_human(item)
+
+    if htmlOutput:
+        print("</body></html>")
     sys.exit(0)
+
 # Basic freetext search (in vulnerability summary).
 # Full-text indexing is more efficient to search across all CVEs.
 if vFreeSearch:
     try:
         for item in db.getFreeText(vFreeSearch):
-            printCVE(item, indent=2)
+            printCVE_json(item, indent=2)
     except:
         sys.exit("Free text search not enabled on the database!")
     sys.exit(0)
@@ -139,68 +221,19 @@ if vFreeSearch:
 if vSearch:
     for item in db.cvesForCPE(vSearch):
         if csvOutput:
-            # We assume that the vendor name is usually in the hostame of the
-            # URL to avoid any match on the resource part
-            refs = []
-            for entry in item['references']:
-                if args.v is not None:
-                    url = urlparse(entry)
-                    hostname = url.netloc
-                    if re.search(args.v, hostname):
-                        refs.append(entry)
-            if not refs:
-                refs = "[no vendor link found]"
-            if namelookup:
-                nl = " ".join(item['vulnerable_configuration'])
-            csvoutput = csv.writer(sys.stdout, delimiter='|', quotechar='|', quoting=csv.QUOTE_MINIMAL)
-            if not namelookup:
-                csvoutput.writerow([item['id'], str(item['Published']), item['cvss'], item['summary'], refs])
-            else:
-                csvoutput.writerow([item['id'], str(item['Published']), item['cvss'], item['summary'], refs, nl])
+            printCVE_csv(item)
         elif htmlOutput:
-            print("<h2>" + item['id'] + "<br></h2>CVSS score: " + str(item['cvss']) + "<br>" + "<b>" + str(item['Published']) + "<b><br>" + item['summary'] + "<br>")
-            print("References:<br>")
-            for entry in item['references']:
-                print(entry + "<br>")
-            print("<hr><hr>")
+            printCVE_html(item)
         # bson straight from the MongoDB db - converted to JSON default
         # representation
         elif jsonOutput:
-            printCVE(item)
+            printCVE_json(item)
         elif xmlOutput:
-            c = SubElement(r, 'id')
-            c.text = item['id']
-            c = SubElement(r, 'Published')
-            c.text = str(item['Published'])
-            c = SubElement(r, 'cvss')
-            c.text = str(item['cvss'])
-            c = SubElement(r, 'summary')
-            c.text = SaxEscape(item['summary'])
-            for e in item['references']:
-                c = SubElement(r, 'references')
-                c.text = SaxEscape(e)
-            for e in item['vulnerable_configuration']:
-                c = SubElement(r, 'vulnerable_configuration')
-                c.text = SaxEscape(e)
+            printCVE_xml(item)
         elif cveidOutput:
-            print(item['id'])
+            printCVE_id(item)
         else:
-            print("CVE\t: " + item['id'])
-            print("DATE\t: " + str(item['Published']))
-            print("CVSS\t: " + str(item['cvss']))
-            print(item['summary'])
-            print("\nReferences:")
-            print("-----------")
-            for entry in item['references']:
-                print(entry)
-            print("\nVulnerable Configs:")
-            print("-------------------")
-            for entry in item['vulnerable_configuration']:
-                if not namelookup:
-                    print(entry)
-                else:
-                    print(cves.getcpe(cpeid=entry))
-            print("\n\n")
+            printCVE_human(item)
 
     if htmlOutput:
         print("</body></html>")


### PR DESCRIPTION
This PR does 
1 - make several display functions (printCVE_html, printCVE_csv, printCVE_xml, printCVE_id, printCVE_human and rename printCVE to printCVE_json)
2 - use these functions for the -c arg according to the -o arg specify

I didn't code it for the freetext search as i can't test it with my current setup.