### PR TITLE
Bugfix: web server login broken

### DIFF
--- a/web/index.py
+++ b/web/index.py
@@ -82,7 +82,8 @@ class Index(Minimal):
               {'r': '/admin/listmanagement',                    'm': ['GET'],  'f': self.listManagement},
               {'r': '/admin/listmanagement/<vendor>',           'm': ['GET'],  'f': self.listManagement},
               {'r': '/admin/listmanagement/<vendor>/<product>', 'm': ['GET'],  'f': self.listManagement},
-              {'r': '/admin/listmanagement/add',                'm': ['GET'],  'f': self.listManagementAdd}]
+              {'r': '/admin/listmanagement/add',                'm': ['GET'],  'f': self.listManagementAdd},
+              {'r': '/login',                                   'm': ['POST'], 'f': self.login_check}]
     for route in routes: self.addRoute(route)
 
 
@@ -500,7 +501,7 @@ class Index(Minimal):
     try:
       if person and person.authenticate(password):
         login_user(person)
-        return render_template('admin.html', status="logged_in", **adminInfo())
+        return render_template('admin.html', status="logged_in", **self.adminInfo())
       else:
         return render_template('login.html', status="wrong_user_pass")
     except Exception as e:


### PR DESCRIPTION
Web login is broken (404) since the major rework of web/index.py in a409c2c, 2016-12-22.

This is because:
1/ The '/login' flask route is not mapped anymore, resulting in a 404.
2/ Once 1/ is fixed, login result in a spurious ""The database model is outdated! Please update to the latest database model", because an exception is thrown during login. This is not because of an actual database issue,  the exception actually being "name 'adminInfo' is not defined": correct, there is no module wide adminInfo() function anymore, it's been replaced by a adminInfo() method to the Index class. The except clause is too wide, but oh well...

Now, considering a409c2c is a _massive_ commit impacting 9 files, I'd expect there are more things to check and possibly fix. To a bare minimum in web/index.py, there is another use of adminInfo() at the end of listImport() that looks wrong. Yet, rather than creating another _big_ commit, here is a small one to begin with.