### PR TITLE
Ensure that redis-cache-cpe runs when selected

### DIFF
--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -99,7 +99,7 @@ while (loop):
         loop = False
     newelement = 0
     for source in sources:
-        if not Configuration.includesFeed(source['name']):
+        if not Configuration.includesFeed(source['name']) and source['name'] is not "redis-cache-cpe":
             continue
         if args.f and source['name'] is not "redis-cache-cpe":
             log("Dropping collection: " + source['name'])


### PR DESCRIPTION
Due to the change in behaviour of Configuration.includesFeed (https://github.com/cve-search/cve-search/blob/master/lib/Config.py#L294), the option "redis-cache-cpe" is not executed when running db_updated.py -c 

redis-cache-cpe doesn't have a feed, so includesFeed will return false, and the process will continue to the next element of the db_update process. Before it would return True by default. 

Since it continues, sbin/db_updater.py#L123 is never triggered. 

