### PR TITLE
Convert wrong encoding of CPE2.3

### DIFF
--- a/lib/Toolkit.py
+++ b/lib/Toolkit.py
@@ -24,6 +24,7 @@ def toStringFormattedCPE(cpe,autofill=False):
       cpe=cpe.replace('~',':-:')
       cpe=cpe.replace('::',':')
       cpe=cpe.strip(':-')
+      cpe=unquote(cpe)
     if autofill:
       e=cpe.split(':')
       for x in range(0,13-len(e)):
@@ -119,3 +120,8 @@ def compile(regexes):
   for rule in regexes:
     r.append(re.compile(rule))
   return r
+
+# Convert cpe2.2 url encoded to cpe2.3 char escaped
+# cpe:2.3:o:cisco:ios:12.2%281%29 to cpe:2.3:o:cisco:ios:12.2\(1\)
+def unquote(cpe):
+  return re.compile('%([0-9a-fA-F]{2})',re.M).sub(lambda m: "\\" + chr(int(m.group(1),16)), cpe)


### PR DESCRIPTION
Add the unquote function to convert the url encoded to escaped character.
This pull request address the #256 issue.