### PR TITLE
Pin Flask-PyMongo 0.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 flask
 flask-login<=0.2.11
-flask-pymongo
+flask-pymongo<2.0
 irc
 itsdangerous
 lxml


### PR DESCRIPTION
In about the next month, Flask-PyMongo 2.0 is going to be released, which is not (necessarily) compatible with 0.x versions. This change will prevent accidental updates, but I'd also be happy to work with you on upgrading safely to 2.0, which will be the base version going forward that will receive compatibility and bug fix improvements, etc.