### PR TITLE
Update NVD feeds

### DIFF
--- a/etc/sources.ini.sample
+++ b/etc/sources.ini.sample
@@ -1,6 +1,6 @@
 [Sources]
-CVE:    https://static.nvd.nist.gov/feeds/xml/cve/
-CPE:    https://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.zip
+CVE:    https://nvd.nist.gov/feeds/xml/cve/2.0/
+CPE:    https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.zip
 CWE:    https://cwe.mitre.org/data/xml/cwec_v2.8.xml.zip
 CAPEC:  https://capec.mitre.org/data/xml/capec_v2.6.xml
 VIA4:   https://www.cve-search.org/feeds/via4.json

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -51,8 +51,8 @@ class Configuration():
                'plugin_config': './etc/plugins.ini',
                'auth_load': './etc/auth.txt'
                }
-    sources={'cve':        "https://static.nvd.nist.gov/feeds/xml/cve/",
-             'cpe':        "https://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml",
+    sources={'cve':        "https://nvd.nist.gov/feeds/xml/cve/2.0/",
+             'cpe':        "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.zip",
              'cwe':        "https://cwe.mitre.org/data/xml/cwec_v2.12.xml.zip",
              'capec':      "https://capec.mitre.org/data/xml/capec_v2.6.xml",
              'via4':       "https://www.cve-search.org/feeds/via4.json",


### PR DESCRIPTION
I noticed that my nightly server database did not happen.
From a CLI:
```
==========================
Fri 29 June 2018 08:14
==========================
Starting cve
Cannot open url https://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-modified.xml.gz. Bad URL or not connected to the internet?
cve has 108929 elements (0 update)
Starting cpe
Cannot open url https://static.nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.zip. Bad URL or not connected to the internet?
cpe has 145969 elements (0 update)
...etc
```

As a side note it would be nice if these went also to the server persistent log, I could add that too. But in the meantime I'm a bit puzzled: it's been a while since the major NVD site redesign. I don't visit it daily, but was this change of URL announced? Why did it break *today*?

Can anybody reproduce my issue?