### PR TITLE
Issue 308: Updated documentation how to fulltext index all the CVEs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Fulltext indexing
 
 If you want to index all the CVEs from your current MongoDB collection:
 
-    ./sbin/db_fulltext.py
+    ./sbin/db_fulltext.py -l 0
 
 and you query the fulltext index (to get a list of matching CVE-ID):
 


### PR DESCRIPTION
The current explanation how to fulltext index all the CVE's indexes the last 5 CVE only.

This PR updates the documentation accordingly.


