### PR TITLE
Cwe completeness: added related weaknesses and categories

### DIFF
--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -52,6 +52,7 @@ class CWEHandler(ContentHandler):
         self.weakness_tag = False
         self.weakness_relationships_tag = False
         self.relationship_tag = False
+        self.relationship_views_tag = False
         self.relationship_view_tag = False
         self.relationship_target_tag = False
         self.relationship_nature_tag = False
@@ -92,10 +93,14 @@ class CWEHandler(ContentHandler):
             self.relationship_tag = True
             self.relationship = {}
 
-        elif name == 'Relationship_View_ID' and self.relationship_tag:
+        elif name == 'Relationship_Views' and self.relationship_tag:
+            self.relationship_views_tag = True
+            self.relationship_views = []
+
+        elif name == 'Relationship_View_ID' and self.relationship_views_tag:
             self.relationship_view_tag = True
-            self.relationship_view = ""
-            self.view_id = []
+            self.relationship_view_id = ""
+
         elif name == 'Relationship_Target_Form' and self.relationship_tag:
             self.relationship_target_tag = True
             self.relationship_target = ""
@@ -110,7 +115,7 @@ class CWEHandler(ContentHandler):
         if self.description_summary_tag:
             self.description_summary += ch.replace("       ", "")
         if self.relationship_view_tag:
-            self.relationship_view += ch.replace("       ", "")
+            self.relationship_view_id += ch.replace("       ", "")
         if self.relationship_target_tag:
             self.relationship_target += ch.replace("       ", "")
         if self.relationship_nature_tag:
@@ -146,8 +151,11 @@ class CWEHandler(ContentHandler):
 
         elif name == 'Relationship_View_ID' and self.relationship_tag:
             self.relationship_view_tag = False
-            self.relationship_view = self.relationship_view
-            self.relationship['view_id'] = self.relationship_view
+            self.relationship_views.append(self.relationship_view_id)
+
+        elif name == 'Relationship_Views' and self.relationship_views_tag:
+            self.relationship_views_tag = False
+            self.relationship['view_id'] = self.relationship_views
 
         elif name == 'Relationship_Target_Form' and self.relationship_tag:
             self.relationship_target_tag = False
@@ -186,13 +194,19 @@ if i is not None and not args.f:
 # parse xml and store in database
 parser.parse(f)
 cweList = []
+
 for cwe in progressbar(ch.cwe):
     cwe['description_summary'] = cwe['description_summary'].replace("\t\t\t\t\t", " ")
     if args.v:
         print (cwe)
     cweList.append(cwe)
 
-db.bulkUpdate('cwe', cweList)
-
-#update database info after successful program-run
-db.setColUpdate('cwe', lastmodified)
+# import json
+#
+# with open("cwe_json.txt", 'w') as outfile:
+#     outfile.write(json.dumps(cweList))
+#
+# db.bulkUpdate('cwe', cweList)
+#
+# #update database info after successful program-run
+# db.setColUpdate('cwe', lastmodified)

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -201,12 +201,7 @@ for cwe in progressbar(ch.cwe):
         print (cwe)
     cweList.append(cwe)
 
-# import json
-#
-# with open("cwe_json.txt", 'w') as outfile:
-#     outfile.write(json.dumps(cweList))
-#
-# db.bulkUpdate('cwe', cweList)
-#
-# #update database info after successful program-run
-# db.setColUpdate('cwe', lastmodified)
+db.bulkUpdate('cwe', cweList)
+
+#update database info after successful program-run
+db.setColUpdate('cwe', lastmodified)

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -191,8 +191,8 @@ for cwe in progressbar(ch.cwe):
     if args.v:
         print (cwe)
     cweList.append(cwe)
-#
-# db.bulkUpdate('cwe', cweList)
-#
-# #update database info after successful program-run
-# db.setColUpdate('cwe', lastmodified)
+
+db.bulkUpdate('cwe', cweList)
+
+#update database info after successful program-run
+db.setColUpdate('cwe', lastmodified)

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -40,6 +40,7 @@ import lib.DatabaseLayer as db
 
 argparser = argparse.ArgumentParser(description='populate/update NIST CWE Common Weakness Enumeration database')
 argparser.add_argument('-v', action='store_true', help='verbose output')
+argparser.add_argument('-f', action='store_true', help='force update')
 args = argparser.parse_args()
 
 
@@ -153,11 +154,11 @@ except Exception as e:
     sys.exit("Cannot open url %s. Bad URL or not connected to the internet?" % (Configuration.getFeedURL("cwe")))
 lastmodified = parse_datetime(r.headers['last-modified'], ignoretz=True)
 i = db.getLastModified('cwe')
-# if i is not None:
-#     if lastmodified == i:
-#         print("Not modified")
-#         sys.exit(0)
-#
+if i is not None and not args.f:
+    if lastmodified == i:
+        print("Not modified")
+        sys.exit(0)
+
 
 # parse xml and store in database
 parser.parse(f)
@@ -167,8 +168,8 @@ for cwe in progressbar(ch.cwe):
     if args.v:
         print (cwe)
     cweList.append(cwe)
-print(Configuration.getFeedURL("cwe"))
-# db.bulkUpdate('cwe', cweList)
-#
-# #update database info after successful program-run
-# db.setColUpdate('cwe', lastmodified)
+
+db.bulkUpdate('cwe', cweList)
+
+#update database info after successful program-run
+db.setColUpdate('cwe', lastmodified)

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -46,11 +46,14 @@ args = argparser.parse_args()
 class CWEHandler(ContentHandler):
     def __init__(self):
         self.cwe = []
-        self.category = []
         self.description_summary_tag = False
         self.weakness_tag = False
-        self.related_weakness_tag = False
-
+        self.weakness_relationships_tag = False
+        self.relationship_tag = False
+        self.relationship_view_tag = False
+        self.relationship_target_tag = False
+        self.relationship_nature_tag = False
+        self.relationship_id_tag = False
 
     def startElement(self, name, attrs):
 
@@ -66,19 +69,40 @@ class CWEHandler(ContentHandler):
         elif name == 'Description_Summary' and self.weakness_tag:
             self.description_summary_tag = True
             self.description_summary = ""
-        elif name == 'Related_Weaknesses' and self.weakness_tag:
-            self.related_weaknesses_sub_tag = True
-            self.related_weaknesses = []
-        elif name == 'Related_Weakness' and self.related_weaknesses_sub_tag:
-            self.related_weakness_tag = True
-            self.nature = attrs.get('Nature')
-            self.id = attrs.get('CWE_ID')
-            self.view = attrs.get('View_ID')
-            self.related = {'related_id': self.id, 'related_nature': self.nature, 'related_view': self.view}
+
+        elif name == 'Relationships' and self.weakness_tag:
+            self.weakness_relationships_tag = True
+            self.relationships = []
+
+        elif name == 'Relationship' and self.weakness_relationships_tag:
+            self.relationship_tag = True
+            self.relationship = {}
+
+        elif name == 'Relationship_View_ID' and self.relationship_tag:
+            self.relationship_view_tag = True
+            self.relationship_view = ""
+            self.view_id = []
+        elif name == 'Relationship_Target_Form' and self.relationship_tag:
+            self.relationship_target_tag = True
+            self.relationship_target = ""
+        elif name == 'Relationship_Nature' and self.relationship_tag:
+            self.relationship_nature_tag = True
+            self.relationship_nature = ""
+        elif name == 'Relationship_Target_ID' and self.relationship_tag:
+            self.relationship_id_tag = True
+            self.relationship_id = ""
 
     def characters(self, ch):
         if self.description_summary_tag:
             self.description_summary += ch.replace("       ", "")
+        if self.relationship_view_tag:
+            self.relationship_view += ch.replace("       ", "")
+        if self.relationship_target_tag:
+            self.relationship_target += ch.replace("       ", "")
+        if self.relationship_nature_tag:
+            self.relationship_nature += ch.replace("       ", "")
+        if self.relationship_id_tag:
+            self.relationship_id += ch.replace("       ", "")
 
     def endElement(self, name):
         if name == 'Description_Summary' and self.weakness_tag:
@@ -87,12 +111,34 @@ class CWEHandler(ContentHandler):
             self.cwe[-1]['description_summary'] = self.description_summary.replace("\n", "")
         elif name == 'Weakness' and self.weakness_tag:
             self.weakness_tag = False
-        elif name == 'Related_Weaknesses' and self.related_weaknesses_sub_tag:
-            self.related_weaknesses_sub_tag = False
-            self.cwe[-1]['related_weaknesse'] = self.related_weaknesses
-        elif name == 'Related_Weakness' and self.related_weakness_tag:
-            self.related_weakness_tag = False
-            self.related_weaknesses.append(self.related)
+
+        elif name == 'Relationships' and self.weakness_tag:
+            self.weakness_relationships_tag = False
+            self.cwe[-1]['relationships'] = self.relationships
+
+        elif name == 'Relationship' and self.weakness_relationships_tag:
+            self.relationship_tag = False
+            self.relationships.append(self.relationship)
+
+        elif name == 'Relationship_View_ID' and self.relationship_tag:
+            self.relationship_view_tag = False
+            self.relationship_view = self.relationship_view
+            self.relationship['view_id'] = self.relationship_view
+
+        elif name == 'Relationship_Target_Form' and self.relationship_tag:
+            self.relationship_target_tag = False
+            self.relationship_target = self.relationship_target
+            self.relationship['abs'] = self.relationship_target
+
+        elif name == 'Relationship_Nature' and self.relationship_tag:
+            self.relationship_nature_tag = False
+            self.relationship_nature = self.relationship_nature
+            self.relationship['nature'] = self.relationship_nature
+
+        elif name == 'Relationship_Target_ID' and self.relationship_tag:
+            self.relationship_id_tag = False
+            self.relationship_id = self.relationship_id
+            self.relationship['cwe_id'] = self.relationship_id
 
 
 # make parser
@@ -121,6 +167,7 @@ for cwe in progressbar(ch.cwe):
     if args.v:
         print (cwe)
     cweList.append(cwe)
+print(Configuration.getFeedURL("cwe"))
 # db.bulkUpdate('cwe', cweList)
 #
 # #update database info after successful program-run

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -48,6 +48,7 @@ class CWEHandler(ContentHandler):
     def __init__(self):
         self.cwe = []
         self.description_summary_tag = False
+        self.category_tag = False
         self.weakness_tag = False
         self.weakness_relationships_tag = False
         self.relationship_tag = False
@@ -67,11 +68,23 @@ class CWEHandler(ContentHandler):
             self.status = attrs.get('Status')
             self.cwe.append({'name': self.name, 'id': self.idname, 'status': self.status,
                              'weaknessabs': self.weaknessabs})
-        elif name == 'Description_Summary' and self.weakness_tag:
+        elif name == 'Category':
+            self.category_tag = True
+            self.category_name = attrs.get('Name')
+            self.category_id = attrs.get('ID')
+            self.category_status = attrs.get('Status')
+            self.cwe.append({
+                'name': self.category_name,
+                'id': self.category_id,
+                'status': self.category_status,
+                'weaknessabs': 'Category'
+            })
+
+        elif name == 'Description_Summary' and (self.weakness_tag or self.category_tag):
             self.description_summary_tag = True
             self.description_summary = ""
 
-        elif name == 'Relationships' and self.weakness_tag:
+        elif name == 'Relationships' and (self.weakness_tag or self.category_tag):
             self.weakness_relationships_tag = True
             self.relationships = []
 
@@ -110,10 +123,20 @@ class CWEHandler(ContentHandler):
             self.description_summary_tag = False
             self.description_summary = self.description_summary + self.description_summary
             self.cwe[-1]['description_summary'] = self.description_summary.replace("\n", "")
+        if name == 'Description_Summary' and self.category_tag:
+            self.description_summary_tag = False
+            self.description_summary = self.description_summary + self.description_summary
+            self.cwe[-1]['description_summary'] = self.description_summary.replace("\n", "")
+
         elif name == 'Weakness' and self.weakness_tag:
             self.weakness_tag = False
+        elif name == 'Category' and self.category_tag:
+            self.category_tag = False
 
         elif name == 'Relationships' and self.weakness_tag:
+            self.weakness_relationships_tag = False
+            self.cwe[-1]['relationships'] = self.relationships
+        elif name == 'Relationships' and self.category_tag:
             self.weakness_relationships_tag = False
             self.cwe[-1]['relationships'] = self.relationships
 
@@ -129,7 +152,7 @@ class CWEHandler(ContentHandler):
         elif name == 'Relationship_Target_Form' and self.relationship_tag:
             self.relationship_target_tag = False
             self.relationship_target = self.relationship_target
-            self.relationship['abs'] = self.relationship_target
+            self.relationship['weaknessabs'] = self.relationship_target
 
         elif name == 'Relationship_Nature' and self.relationship_tag:
             self.relationship_nature_tag = False
@@ -168,8 +191,8 @@ for cwe in progressbar(ch.cwe):
     if args.v:
         print (cwe)
     cweList.append(cwe)
-
-db.bulkUpdate('cwe', cweList)
-
-#update database info after successful program-run
-db.setColUpdate('cwe', lastmodified)
+#
+# db.bulkUpdate('cwe', cweList)
+#
+# #update database info after successful program-run
+# db.setColUpdate('cwe', lastmodified)

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -42,13 +42,18 @@ argparser = argparse.ArgumentParser(description='populate/update NIST CWE Common
 argparser.add_argument('-v', action='store_true', help='verbose output')
 args = argparser.parse_args()
 
+
 class CWEHandler(ContentHandler):
     def __init__(self):
         self.cwe = []
+        self.category = []
         self.description_summary_tag = False
         self.weakness_tag = False
+        self.related_weakness_tag = False
+
 
     def startElement(self, name, attrs):
+
         if name == 'Weakness':
             self.weakness_tag = True
             self.statement = ""
@@ -56,10 +61,20 @@ class CWEHandler(ContentHandler):
             self.name = attrs.get('Name')
             self.idname = attrs.get('ID')
             self.status = attrs.get('Status')
-            self.cwe.append({'name': self.name, 'id': self.idname, 'status': self.status, 'weaknessabs': self.weaknessabs})
+            self.cwe.append({'name': self.name, 'id': self.idname, 'status': self.status,
+                             'weaknessabs': self.weaknessabs})
         elif name == 'Description_Summary' and self.weakness_tag:
             self.description_summary_tag = True
             self.description_summary = ""
+        elif name == 'Related_Weaknesses' and self.weakness_tag:
+            self.related_weaknesses_sub_tag = True
+            self.related_weaknesses = []
+        elif name == 'Related_Weakness' and self.related_weaknesses_sub_tag:
+            self.related_weakness_tag = True
+            self.nature = attrs.get('Nature')
+            self.id = attrs.get('CWE_ID')
+            self.view = attrs.get('View_ID')
+            self.related = {'related_id': self.id, 'related_nature': self.nature, 'related_view': self.view}
 
     def characters(self, ch):
         if self.description_summary_tag:
@@ -70,8 +85,15 @@ class CWEHandler(ContentHandler):
             self.description_summary_tag = False
             self.description_summary = self.description_summary + self.description_summary
             self.cwe[-1]['description_summary'] = self.description_summary.replace("\n", "")
-        elif name == 'Weakness':
+        elif name == 'Weakness' and self.weakness_tag:
             self.weakness_tag = False
+        elif name == 'Related_Weaknesses' and self.related_weaknesses_sub_tag:
+            self.related_weaknesses_sub_tag = False
+            self.cwe[-1]['related_weaknesse'] = self.related_weaknesses
+        elif name == 'Related_Weakness' and self.related_weakness_tag:
+            self.related_weakness_tag = False
+            self.related_weaknesses.append(self.related)
+
 
 # make parser
 parser = make_parser()
@@ -82,24 +104,24 @@ try:
     (f, r) = Configuration.getFeedData('cwe')
 except Exception as e:
     print(e)
-    sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL("cwe")))
+    sys.exit("Cannot open url %s. Bad URL or not connected to the internet?" % (Configuration.getFeedURL("cwe")))
 lastmodified = parse_datetime(r.headers['last-modified'], ignoretz=True)
 i = db.getLastModified('cwe')
-if i is not None:
-    if lastmodified == i:
-        print("Not modified")
-        sys.exit(0)
-
+# if i is not None:
+#     if lastmodified == i:
+#         print("Not modified")
+#         sys.exit(0)
+#
 
 # parse xml and store in database
 parser.parse(f)
-cweList=[]
+cweList = []
 for cwe in progressbar(ch.cwe):
-    cwe['description_summary']=cwe['description_summary'].replace("\t\t\t\t\t", " ")
+    cwe['description_summary'] = cwe['description_summary'].replace("\t\t\t\t\t", " ")
     if args.v:
         print (cwe)
     cweList.append(cwe)
-db.bulkUpdate('cwe', cweList)
-
-#update database info after successful program-run
-db.setColUpdate('cwe', lastmodified)
+# db.bulkUpdate('cwe', cweList)
+#
+# #update database info after successful program-run
+# db.setColUpdate('cwe', lastmodified)


### PR DESCRIPTION
As raised in issue [321](https://github.com/cve-search/cve-search/issues/321),

Here is a fix to add related weaknesses to each cwe and categories, to keep the full tree structure.

I also add a flag to force update of the db inside the db_mgmt_cwe script, to overwrite the last modified check.

The first commit is useless as I was working on the xml version 2.11
