### PR TITLE
Update dump_last.py

### DIFF
--- a/bin/dump_last.py
+++ b/bin/dump_last.py
@@ -17,6 +17,7 @@ sys.path.append(os.path.join(runPath, ".."))
 import time
 import datetime
 import argparse
+import html
 
 import lib.CVEs as cves
 
@@ -67,11 +68,11 @@ for x in cvelist.get(limit=last):
     else:
         print ("<div class=\"cve\"><table><tbody>")
         print ("<tr class=\"alt\">")
-        print ("<td>" + str(x['id']) + " - " + x['summary'][:90] + "...</td>")
+        print ("<td>" + str(x['id']) + " - " + html.escape(x['summary'][:90]) + "...</td>")
         print ("</tr>")
         print ("<tr><td>CVSS: " + str(x['cvss']) + " Published: " + str(x['Published']) + "</td></tr>")
         print ("<tr>")
-        print ("<td> Summary: " + x['summary'] + "</td>")
+        print ("<td> Summary: " + html.escape(x['summary']) + "</td>")
         print ("</tr>")
         print ("<tr><td>Vulnerable configuration:</td></tr>")
         print ("<tr><td><ul>")


### PR DESCRIPTION
Add html.escape for summary in html output for html-qoute in dump_last.py. In summary for CVE-2019-9624 is the comment-sequence "<!--". If you create in html-output the Browser doesnt show all because of the "<!--" command.