### PR TITLE
Setting redis password

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -32,7 +32,7 @@ class Configuration():
     ConfigParser.read(os.path.join(runPath, "../etc/configuration.ini"))
     default = {'redisHost': 'localhost', 'redisPort': 6379,
                'redisVendorDB': 10,      'redisNotificationsDB': 11,
-               'redisRefDB': 12,
+               'redisRefDB': 12, 'redisPass': None,
                'mongoHost': 'localhost', 'mongoPort': 27017,
                'mongoDB': "cvedb",
                'mongoUsername': '', 'mongoPassword': '',
@@ -120,21 +120,24 @@ class Configuration():
         redisHost = cls.getRedisHost()
         redisPort = cls.getRedisPort()
         redisDB = cls.readSetting("Redis", "VendorsDB", cls.default['redisVendorDB'])
-        return redis.StrictRedis(host=redisHost, port=redisPort, db=redisDB, charset='utf-8', decode_responses=True)
+        redisPass = cls.readSetting("Redis", "Password", cls.default['redisPass'])
+        return redis.StrictRedis(host=redisHost, port=redisPort, db=redisDB, password=redisPass, charset='utf-8', decode_responses=True)
 
     @classmethod
     def getRedisNotificationsConnection(cls):
         redisHost = cls.getRedisHost()
         redisPort = cls.getRedisPort()
         redisDB = cls.readSetting("Redis", "NotificationsDB", cls.default['redisNotificationsDB'])
-        return redis.StrictRedis(host=redisHost, port=redisPort, db=redisDB, charset="utf-8", decode_responses=True)
+        redisPass = cls.readSetting("Redis", "Password", cls.default['redisPass'])
+        return redis.StrictRedis(host=redisHost, port=redisPort, db=redisDB, password=redisPass, charset="utf-8", decode_responses=True)
 
     @classmethod
     def getRedisRefConnection(cls):
         redisHost = cls.getRedisHost()
         redisPort = cls.getRedisPort()
         redisDB = cls.readSetting("Redis", "RefDB", cls.default['redisRefDB'])
-        return redis.StrictRedis(host=redisHost, port=redisPort, db=redisDB, charset="utf-8", decode_responses=True)
+        redisPass = cls.readSetting("Redis", "Password", cls.default['redisPass'])
+        return redis.StrictRedis(host=redisHost, port=redisPort, db=redisDB, password=redisPass, charset="utf-8", decode_responses=True)
 
     # Flask
     @classmethod
@@ -233,7 +236,7 @@ class Configuration():
             return base * multiplier
         except Exception as e:
             print(e)
-            return 100 * 1024        
+            return 100 * 1024
 
     @classmethod
     def getBacklog(cls):


### PR DESCRIPTION
Optionally, with this change we are able to connect to a Redis server that is protected with a password.
This password is provided in the configuration.ini, in the Redis section, with the keyword "Password".
By default, the password is None, as currently happens