### PR TITLE
Update CPE to use JSON feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Populating the database
 
 For the initial run, you need to populate the CVE database by running:
 
+    ./sbin/db_mgmt_cpe_dictionary.py -p
     ./sbin/db_mgmt_json.py -p
-    ./sbin/db_mgmt_cpe_dictionary.py # This will take >45minutes on a decent machine, please be patient
     ./sbin/db_updater.py -c # This will take >45minutes on a decent machine, please be patient
 
 It will fetch all the existing JSON files from the Common Vulnerabilities
@@ -125,7 +125,7 @@ The reference database has 3 additional sources:
 Updating the database
 ---------------------
 
-An updater script helps to start the db_mgmt_*  
+An updater script helps to start the db_mgmt_*
 
     ./sbin/db_updater.py -v
 
@@ -274,7 +274,7 @@ curl http://127.0.0.1:5000/api/browse/
 Dump the product of a specific vendor in JSON
 
 ~~~
-curl  http://127.0.0.1:5000/api/browse/zyxel 
+curl  http://127.0.0.1:5000/api/browse/zyxel
 {
   "product": [
     "n300_netusb_nbg-419n",

--- a/etc/sources.ini.sample
+++ b/etc/sources.ini.sample
@@ -1,6 +1,6 @@
 [Sources]
 CVE:    https://nvd.nist.gov/feeds/json/cve/1.0/
-CPE:    https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.zip
+CPE:    https://nvd.nist.gov/feeds/json/cpematch/1.0/nvdcpematch-1.0.json.zip
 CWE:    https://cwe.mitre.org/data/xml/cwec_v3.1.xml.zip
 CAPEC:  https://capec.mitre.org/data/xml/capec_v3.0.xml
 VIA4:   https://www.cve-search.org/feeds/via4.json

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -53,7 +53,7 @@ class Configuration():
                }
     #jdt_NOTE: chceck if these default data sources are up to date
     sources={'cve':        "https://nvd.nist.gov/feeds/json/cve/1.0/",
-             'cpe':        "https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.2.xml.zip",
+             'cpe':        "https://nvd.nist.gov/feeds/json/cpematch/1.0/nvdcpematch-1.0.json.zip",
              'cwe':        "https://cwe.mitre.org/data/xml/cwec_v2.12.xml.zip",
              'capec':      "https://capec.mitre.org/data/xml/capec_v2.6.xml",
              'via4':       "https://www.cve-search.org/feeds/via4.json",
@@ -271,7 +271,7 @@ class Configuration():
         data = response
         # TODO: if data == text/plain; charset=utf-8, read and decode
         if unpack:
-            if   'gzip' in response.info().get('Content-Type'):
+            if 'gzip' in response.info().get('Content-Type'):
                 buf = BytesIO(response.read())
                 data = gzip.GzipFile(fileobj=buf)
             elif 'bzip2' in response.info().get('Content-Type'):

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -67,6 +67,7 @@ def insertCVE(cve):
 
 def updateCVE(cve):
   colCVE.update({"id": cve['id']}, {"$set": {"cvss": cve['cvss'], "summary": cve['summary'], "references": cve['references'],
+                                             "vulnerable_product": cve["vulnerable_product"],
                                              "cwe": cve['cwe'], "vulnerable_configuration": cve['vulnerable_configuration'],
                                              "vulnerable_configuration_cpe_2_2": cve['vulnerable_configuration_cpe_2_2'], 'last-modified': cve['Modified']}})
 

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -70,6 +70,13 @@ def updateCVE(cve):
                                              "cwe": cve['cwe'], "vulnerable_configuration": cve['vulnerable_configuration'],
                                              "vulnerable_configuration_cpe_2_2": cve['vulnerable_configuration_cpe_2_2'], 'last-modified': cve['Modified']}})
 
+def bulkInsert(collection, data):
+  if len(data)>0:
+    bulk=db[collection].initialize_unordered_bulk_op()
+    for x in data:
+      bulk.insert(x)
+    bulk.execute()
+
 def bulkUpdate(collection, data):
   if len(data)>0:
     bulk=db[collection].initialize_unordered_bulk_op()
@@ -244,6 +251,9 @@ def getCVE(id, collection=None):
 
 def getCPE(id):
   return sanitize(colCPE.find_one({"id": id}))
+
+def getCPEVersionInformation(query):
+  return sanitize(colCPE.find_one(query))
 
 def getCPEs():
   return sanitize(colCPE.find())

--- a/lib/Toolkit.py
+++ b/lib/Toolkit.py
@@ -125,3 +125,33 @@ def compile(regexes):
 # cpe:2.3:o:cisco:ios:12.2%281%29 to cpe:2.3:o:cisco:ios:12.2\(1\)
 def unquote(cpe):
   return re.compile('%([0-9a-fA-F]{2})',re.M).sub(lambda m: "\\" + chr(int(m.group(1),16)), cpe)
+
+# Generates a human readable title from a CPE 2.3 string
+def generate_title(cpe):
+    title = ""
+
+    cpe_split = cpe.split(":")
+    # Do a very basic test to see if the CPE is valid
+    if len(cpe_split) == 13:
+
+        # Combine vendor, product and version
+        title = " ".join(cpe_split[3:6])
+
+        # If "other" is specified, add it to the title
+        if cpe_split[12] != "*":
+            title += cpe_split[12]
+
+        # Capitilize each word
+        title = title.title()
+
+        # If the target_sw is defined, add "for <target_sw>" to title
+        if cpe_split[10] != "*":
+            title += " for " + cpe_split[10]
+
+        # In CPE 2.3 spaces are replaced with underscores. Undo it
+        title = title.replace("_", " ")
+
+        # Special characters are escaped with \. Undo it
+        title = title.replace("\\", "")
+
+    return title

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -28,6 +28,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from dateutil.parser import parse as parse_datetime
 from lib.Config import Configuration
 import lib.DatabaseLayer as db
+from lib.Toolkit import generate_title
 
 # parse command line arguments
 argparser = argparse.ArgumentParser(description='populate/update the local CPE database')
@@ -46,7 +47,7 @@ def process_cpe_item(item=None):
         return None
 
     cpe = {}
-    cpe["title"] = "deprecated"
+    cpe["title"] = generate_title(item["cpe23Uri"])
     cpe["cpe_2_2"] = item["cpe23Uri"]
     cpe["cpe_name"] = item["cpe_name"]
     version_info = ""

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -19,82 +19,95 @@
 # Imports
 import os
 import sys
+import json
+import hashlib
+import argparse
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 
-from xml.sax import make_parser
-from xml.sax.handler import ContentHandler
-
 from dateutil.parser import parse as parse_datetime
-
-from lib.ProgressBar import progressbar
-from lib.Toolkit import toStringFormattedCPE
 from lib.Config import Configuration
 import lib.DatabaseLayer as db
 
-class CPEHandler(ContentHandler):
-    def __init__(self):
-        self.cpe = []
-        self.titletag = False
-        self.referencestag = False
-        self.referencetag = False
+# parse command line arguments
+argparser = argparse.ArgumentParser(description='populate/update the local CPE database')
+argparser.add_argument('-u', action='store_true', help='update the database')
+argparser.add_argument('-p', action='store_true', help='populate the database')
+argparser.add_argument('-a', action='store_true', default=False, help='force populating the CPE database')
+argparser.add_argument('-f', action='store_true', default=False, help='force update of the CPE database')
+argparser.add_argument('-v', action='store_true', help='verbose output')
+args = argparser.parse_args()
 
-    def startElement(self, name, attrs):
-        if name == 'cpe-item':
-            self.name = ""
-            self.title = ""
-            self.referencetitle = ""
-            self.name = attrs.get('name')
-            self.cpe.append({'name': attrs.get('name'), 'title': [], 'references': []})
-        elif name == 'title':
-            if attrs.get('xml:lang') == 'en-US':
-                self.titletag = True
-        elif name == 'references':
-            self.referencestag = True
-        elif name == 'reference':
-            self.referencetag = True
-            self.href = attrs.get('href')
-            self.cpe[-1]['references'].append(self.href)
 
-    def characters(self, ch):
-        if self.titletag:
-            self.title += ch
+def process_cpe_item(item=None):
+    if item is None:
+        return None
+    if "cpe23Uri" not in item:
+        return None
 
-    def endElement(self, name):
-        if name == 'title':
-            self.titletag = False
-            self.cpe[-1]['title'].append(self.title.rstrip())
-        elif name == 'references':
-            self.referencestag = False
-        elif name == 'reference':
-            self.referencetag = False
-            self.href = None
+    cpe = {}
+    cpe["title"] = "deprecated"
+    cpe["cpe_2_2"] = item["cpe23Uri"]
+    cpe["cpe_name"] = item["cpe_name"]
+    version_info = ""
+    if "versionStartExcluding" in item:
+        cpe["versionStartExcluding"] = item["versionStartExcluding"]
+        version_info += cpe["versionStartExcluding"]
+    if "versionStartIncluding" in item:
+        cpe["versionStartIncluding"] = item["versionStartIncluding"]
+        version_info += cpe["versionStartIncluding"]
+    if "versionEndExcluding" in item:
+        cpe["versionEndExcluding"] = item["versionEndExcluding"]
+        version_info += cpe["versionEndExcluding"]
+    if "versionEndIncluding" in item:
+        cpe["versionEndIncluding"] = item["versionEndIncluding"]
+        version_info += cpe["versionEndIncluding"]
 
-# make parser
-parser = make_parser()
-ch = CPEHandler()
-parser.setContentHandler(ch)
-# check modification date
-try:
-    (f, r) = Configuration.getFeedData('cpe')
-except:
-    sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL("cpe")))
-i = db.getLastModified('cpe')
-last_modified = parse_datetime(r.headers['last-modified'], ignoretz=True)
-if i is not None:
-    if last_modified == i:
-        print("Not modified")
-        sys.exit(0)
-# parse xml and store in database
-parser.parse(f)
-cpeList=[]
-for x in progressbar(ch.cpe):
-  x['id']= toStringFormattedCPE(x['name'])
-  x['title']=x['title'][0]
-  x['cpe_2_2'] = x.pop('name')
-  if not x['references']: x.pop('references')
-  cpeList.append(x)
-db.bulkUpdate("cpe", cpeList)
+    sha1_hash = hashlib.sha1(cpe["cpe_2_2"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
+    cpe["id"] = sha1_hash
 
-#update database info after successful program-run
-db.setColUpdate('cpe', last_modified)
+    return cpe
+
+if __name__ == '__main__':
+    if args.u:
+        try:
+            (f, r) = Configuration.getFile(Configuration.getFeedURL('cpe'))
+        except:
+            sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL("cpe")))
+
+        # check modification date
+        i = db.getLastModified('cpe')
+        last_modified = parse_datetime(r.headers['last-modified'], ignoretz=True)
+        if i is not None:
+            if last_modified == i and not args.f:
+                print("Not modified")
+                sys.exit(0)
+
+        cpej = json.loads(f.read())
+        cpeList = []
+        for cpeitem in cpej["matches"]:
+            item = process_cpe_item(cpeitem)
+            cpeList.append(item)
+        db.bulkUpdate("cpe", cpeList)
+
+        #update database info after successful program-run
+        db.setColUpdate('cpe', last_modified)
+    elif args.p:
+        c = db.getSize('cpe')
+        if args.v:
+            print(str(c))
+        if c > 0 and args.a is False:
+            print("Database already populated")
+        else:
+            print("Database population started")
+            try:
+                (f, r) = Configuration.getFile(Configuration.getFeedURL('cpe'))
+            except:
+                sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL("cpe")))
+
+            cpej = json.loads(f.read())
+            cpeList = []
+            for cpeitem in cpej["matches"]:
+                item = process_cpe_item(cpeitem)
+                cpeList.append(item)
+            db.bulkInsert("cpe", cpeList)

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -14,6 +14,7 @@
 # make sure these modules are available on your system
 import os
 import sys
+import hashlib
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 
@@ -92,9 +93,57 @@ def process_cve_item(item=None):
             if 'cpe_match' in cpe:
                 for cpeuri in cpe['cpe_match']:
                     if cpeuri['vulnerable']:
-                        cve['vulnerable_configuration'].append(cpeuri['cpe23Uri'])
+                        query = {}
+                        version_info = ""
+                        if "versionStartExcluding" in cpeuri:
+                            query["versionStartExcluding"] = cpeuri["versionStartExcluding"]
+                            version_info += query["versionStartExcluding"]
+                        if "versionStartIncluding" in cpeuri:
+                            query["versionStartIncluding"] = cpeuri["versionStartIncluding"]
+                            version_info += query["versionStartIncluding"]
+                        if "versionEndExcluding" in cpeuri:
+                            query["versionEndExcluding"] = cpeuri["versionEndExcluding"]
+                            version_info += query["versionEndExcluding"]
+                        if "versionEndIncluding" in cpeuri:
+                            query["versionEndIncluding"] = cpeuri["versionEndIncluding"]
+                            version_info += query["versionEndIncluding"]
+
+                        if query != {}:
+                            query["id"] = hashlib.sha1(cpeuri["cpe23Uri"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
+                            cpe_info = db.getCPEVersionInformation(query)
+                            if cpe_info:
+                                for vulnerable_version in cpe_info["cpe_name"]:
+                                    cve['vulnerable_configuration'].append(vulnerable_version["cpe23Uri"])
+                        else:
+                            # If the cpe_match did not have any of the version start/end modifiers,
+                            # add the CPE string as it is.
+                            cve['vulnerable_configuration'].append(cpeuri['cpe23Uri'])
                     else:
-                        cve['non_vulnerable_configuration'].append(cpeuri['cpe23Uri'])
+                        query = {}
+                        version_info = ""
+                        if "versionStartExcluding" in cpeuri:
+                            query["versionStartExcluding"] = cpeuri["versionStartExcluding"]
+                            version_info += query["versionStartExcluding"]
+                        if "versionStartIncluding" in cpeuri:
+                            query["versionStartIncluding"] = cpeuri["versionStartIncluding"]
+                            version_info += query["versionStartIncluding"]
+                        if "versionEndExcluding" in cpeuri:
+                            query["versionEndExcluding"] = cpeuri["versionEndExcluding"]
+                            version_info += query["versionEndExcluding"]
+                        if "versionEndIncluding" in cpeuri:
+                            query["versionEndIncluding"] = cpeuri["versionEndIncluding"]
+                            version_info += query["versionEndIncluding"]
+
+                        if query != {}:
+                            query["id"] = hashlib.sha1(cpeuri["cpe23Uri"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
+                            cpe_info = db.getCPEVersionInformation(query)
+                            if cpe_info:
+                                for non_vulnerable_version in cpe_info["cpe_name"]:
+                                    cve['non_vulnerable_configuration'].append(non_vulnerable_version["cpe23Uri"])
+                        else:
+                            # If the cpe_match did not have any of the version start/end modifiers,
+                            # add the CPE string as it is.
+                            cve['non_vulnerable_configuration'].append(cpeuri['cpe23Uri'])
             if 'children' in cpe:
                 for child in cpe['children']:
                     if 'cpe_match' in child:

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -88,6 +88,7 @@ def process_cve_item(item=None):
             cve['references'].append(ref['url'])
     if 'configurations' in item:
         cve['vulnerable_configuration'] = []
+        cve['vulnerable_product'] = []
         cve['non_vulnerable_configuration'] = []
         for cpe in item['configurations']['nodes']:
             if 'cpe_match' in cpe:
@@ -114,10 +115,16 @@ def process_cve_item(item=None):
                             if cpe_info:
                                 for vulnerable_version in cpe_info["cpe_name"]:
                                     cve['vulnerable_configuration'].append(vulnerable_version["cpe23Uri"])
+                                    # If the entry is an application, add it to vulnerable_product
+                                    if vulnerable_version["cpe23Uri"].split(":")[2] == "a":
+                                        cve['vulnerable_product'].append(vulnerable_version["cpe23Uri"])
                         else:
                             # If the cpe_match did not have any of the version start/end modifiers,
                             # add the CPE string as it is.
                             cve['vulnerable_configuration'].append(cpeuri['cpe23Uri'])
+                            # If the entry is an application, add it to vulnerable_product
+                            if cpeuri["cpe23Uri"].split(":")[2] == "a":
+                                cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
                     else:
                         query = {}
                         version_info = ""

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -28,7 +28,7 @@ runPath = os.path.dirname(os.path.realpath(__file__))
 sources = [{'name': "cve",
             'updater': "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_json.py"), "-u")},
            {'name': "cpe",
-            'updater': "{} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_cpe_dictionary.py"))},
+            'updater': "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_cpe_dictionary.py"), "-u")},
            {'name': "cpeother",
             'updater': "{} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_cpe_other_dictionary.py"))}]
 
@@ -54,7 +54,7 @@ if not args.m:
                     {'name': 'redis-cache-cpe',
                      'updater': "{} {}".format(sys.executable, os.path.join(runPath, "db_cpe_browser.py"))},
                     {'name': 'via4',
-                     'updater': "{} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_ref.py"))},
+                     'updater': "{} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_ref.py"))}
                     ])
 
 if not args.v:
@@ -73,7 +73,10 @@ def nbelement(collection=None):
 def dropcollection(collection=None):
     if collection is None:
         return False
-    return db.dropCollection(collection)
+    if collection == "cve":
+        collection = "cves"
+    ret = db.dropCollection(collection)
+    return ret
 
 def log(message=""):
     if args.o:
@@ -111,8 +114,11 @@ while (loop):
         if source['name'] is not "redis-cache-cpe":
             log('Starting ' + source['name'])
             before = nbelement(collection=source['name'])
-            if args.f and source['name'] is "cves":
-                updater = "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt.py"), "-p")
+            if args.f and source['name'] is "cve":
+                updater = "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_json.py"), "-pa")
+                subprocess.Popen((shlex.split(updater))).wait()
+            elif args.f and source['name'] is "cpe":
+                updater = "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_cpe_dictionary.py"), "-pa")
                 subprocess.Popen((shlex.split(updater))).wait()
             else:
                 subprocess.Popen((shlex.split(source['updater']))).wait()


### PR DESCRIPTION
Hi,

Now that cve-search uses JSON feed for CVEs, the CPE feed needs to be updated also. This is because the CVE feed no longer lists all the vulnerable configurations, but only a generic CPE 2.3 string along with a version range, e.g. `{"cpe23Uri": "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*" ,"versionEndIncluding": "1.0.2p"}`

This same kind of format is found from the CPE feed. This pull request will fetch all the vulnerable versions from the CPE table when populating the CVE entries.

Because the new CPE feed does not have any single unique value to be used as the ID, I created a hash based on the cpe23Uri and the different version information. For example, in the example above for openssl, the hash would be calculated for `cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*1.0.2p`. When CVEs are added, the same hash is calculated, and the vulnerable versions are fetched based on this value.

I removed the old CPE XML parser and wrote a CPE JSON parser similar to the CVE JSON parser. They both have now the same command line switches. The initial importing of CPEs is now significantly faster, because I added a "bulkInsert" method that does not first check if the entry exists or not, so it works the same way as in the JSON parser.