### PR TITLE
Append all items of CVE description field into summary

### DIFF
--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -66,7 +66,10 @@ def process_cve_item(item=None):
     cve['Modified'] = parse_datetime(item['lastModifiedDate'], ignoretz=True)
     for description in item['cve']['description']['description_data']:
         if description['lang'] == 'en':
-            cve['summary'] = description['value']
+            if "summary" in cve:
+                cve['summary'] += " " + description['value']
+            else:
+                cve['summary'] = description['value']
     if 'impact' in item:
         cve['access'] = {}
         cve['impact'] = {}


### PR DESCRIPTION
Issue #385 pointed the problem where the summary field would hold only the last value of the CVE description if it consisted of many values.

With the changes in this pull request, each element in the CVE description is appended to the summary field.

The problematic CVE in the issue now has the following summary (see picture below). Is it fine as it is, with HTML in the summary?

![image](https://user-images.githubusercontent.com/8766250/67704440-ce7dd900-f9bd-11e9-9cea-8c374f8ef4ab.png)
