### PR TITLE
CPE and CVE fixes

### DIFF
--- a/bin/search.py
+++ b/bin/search.py
@@ -51,7 +51,7 @@ summary_text = ""
 # parse command-line arguments
 argParser = argparse.ArgumentParser(description='Search for vulnerabilities in the National Vulnerability DB. Data from http://nvd.nist.org.')
 argParser.add_argument('-q', type=str, help='Q = search pip requirements file for CVEs, e.g. dep/myreq.txt')
-argParser.add_argument('-p', type=str, nargs='+', help='S = search one or more products, e.g. o:microsoft:windows_7 or o:cisco:ios:12.1 or o:microsoft:windows_7 o:cisco:ios:12.1')
+argParser.add_argument('-p', type=str, nargs='+', help='S = search one or more products, e.g. o:microsoft:windows_7 or o:cisco:ios:12.1 or o:microsoft:windows_7 o:cisco:ios:12.1. Add --only-if-vulnerable if only vulnerabilities that directly affect the product are wanted.')
 argParser.add_argument('--only-if-vulnerable', dest='vulnProdSearch', default=False, action='store_true', help='With this option, "-p" will only return vulnerabilities directly assigned to the product. I.e. it will not consider "windows_7" if it is only mentioned as affected OS in an adobe:reader vulnerability. ')
 argParser.add_argument('--lax', default=False, action='store_true', help='Strict search for software version is disabled. Note that this option only support product description with numerical values only (of the form cisco:ios:1.2.3) ')
 argParser.add_argument('-f', type=str, help='F = free text search in vulnerability summary')

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -101,6 +101,7 @@ if __name__ == '__main__':
             print("Database already populated")
         else:
             print("Database population started")
+            db.dropCollection("cpe")
             try:
                 (f, r) = Configuration.getFile(Configuration.getFeedURL('cpe'))
             except:

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -56,6 +56,24 @@ defaultvalue['cwe'] = "Unknown"
 cveStartYear = Configuration.getCVEStartYear()
 
 
+def get_cpe_info(cpeuri):
+    query = {}
+    version_info = ""
+    if "versionStartExcluding" in cpeuri:
+        query["versionStartExcluding"] = cpeuri["versionStartExcluding"]
+        version_info += query["versionStartExcluding"]
+    if "versionStartIncluding" in cpeuri:
+        query["versionStartIncluding"] = cpeuri["versionStartIncluding"]
+        version_info += query["versionStartIncluding"]
+    if "versionEndExcluding" in cpeuri:
+        query["versionEndExcluding"] = cpeuri["versionEndExcluding"]
+        version_info += query["versionEndExcluding"]
+    if "versionEndIncluding" in cpeuri:
+        query["versionEndIncluding"] = cpeuri["versionEndIncluding"]
+        version_info += query["versionEndIncluding"]
+
+    return query, version_info
+
 def process_cve_item(item=None):
     if item is None:
         return None
@@ -96,20 +114,7 @@ def process_cve_item(item=None):
             if 'cpe_match' in cpe:
                 for cpeuri in cpe['cpe_match']:
                     if cpeuri['vulnerable']:
-                        query = {}
-                        version_info = ""
-                        if "versionStartExcluding" in cpeuri:
-                            query["versionStartExcluding"] = cpeuri["versionStartExcluding"]
-                            version_info += query["versionStartExcluding"]
-                        if "versionStartIncluding" in cpeuri:
-                            query["versionStartIncluding"] = cpeuri["versionStartIncluding"]
-                            version_info += query["versionStartIncluding"]
-                        if "versionEndExcluding" in cpeuri:
-                            query["versionEndExcluding"] = cpeuri["versionEndExcluding"]
-                            version_info += query["versionEndExcluding"]
-                        if "versionEndIncluding" in cpeuri:
-                            query["versionEndIncluding"] = cpeuri["versionEndIncluding"]
-                            version_info += query["versionEndIncluding"]
+                        query, version_info = get_cpe_info(cpeuri)
 
                         if query != {}:
                             query["id"] = hashlib.sha1(cpeuri["cpe23Uri"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
@@ -136,8 +141,24 @@ def process_cve_item(item=None):
                     if 'cpe_match' in child:
                         for cpeuri in child['cpe_match']:
                             if cpeuri['vulnerable']:
-                                cve['vulnerable_configuration'].append(cpeuri['cpe23Uri'])
-                                cve['vulnerable_product'].append(cpeuri['cpe23Uri'])
+                                query, version_info = get_cpe_info(cpeuri)
+                                if query != {}:
+                                    query["id"] = hashlib.sha1(cpeuri["cpe23Uri"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
+                                    cpe_info = db.getCPEVersionInformation(query)
+
+                                    if cpe_info:
+                                        if cpe_info["cpe_name"]:
+                                            for vulnerable_version in cpe_info["cpe_name"]:
+                                                cve['vulnerable_product'].append(vulnerable_version["cpe23Uri"])
+                                                cve['vulnerable_configuration'].append(vulnerable_version["cpe23Uri"])
+                                        else:
+                                            cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
+                                            cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
+                                else:
+                                    # If the cpe_match did not have any of the version start/end modifiers,
+                                    # add the CPE string as it is.
+                                    cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
+                                    cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
                             else:
                                 cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
     if 'problemtype' in item['cve']:

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -92,7 +92,6 @@ def process_cve_item(item=None):
     if 'configurations' in item:
         cve['vulnerable_configuration'] = []
         cve['vulnerable_product'] = []
-        cve['non_vulnerable_configuration'] = []
         for cpe in item['configurations']['nodes']:
             if 'cpe_match' in cpe:
                 for cpeuri in cpe['cpe_match']:
@@ -130,31 +129,8 @@ def process_cve_item(item=None):
                             cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
                             cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
                     else:
-                        query = {}
-                        version_info = ""
-                        if "versionStartExcluding" in cpeuri:
-                            query["versionStartExcluding"] = cpeuri["versionStartExcluding"]
-                            version_info += query["versionStartExcluding"]
-                        if "versionStartIncluding" in cpeuri:
-                            query["versionStartIncluding"] = cpeuri["versionStartIncluding"]
-                            version_info += query["versionStartIncluding"]
-                        if "versionEndExcluding" in cpeuri:
-                            query["versionEndExcluding"] = cpeuri["versionEndExcluding"]
-                            version_info += query["versionEndExcluding"]
-                        if "versionEndIncluding" in cpeuri:
-                            query["versionEndIncluding"] = cpeuri["versionEndIncluding"]
-                            version_info += query["versionEndIncluding"]
+                        cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
 
-                        if query != {}:
-                            query["id"] = hashlib.sha1(cpeuri["cpe23Uri"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
-                            cpe_info = db.getCPEVersionInformation(query)
-                            if cpe_info:
-                                for non_vulnerable_version in cpe_info["cpe_name"]:
-                                    cve['non_vulnerable_configuration'].append(non_vulnerable_version["cpe23Uri"])
-                        else:
-                            # If the cpe_match did not have any of the version start/end modifiers,
-                            # add the CPE string as it is.
-                            cve['non_vulnerable_configuration'].append(cpeuri['cpe23Uri'])
             if 'children' in cpe:
                 for child in cpe['children']:
                     if 'cpe_match' in child:

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -119,22 +119,16 @@ def process_cve_item(item=None):
                             if cpe_info:
                                 if cpe_info["cpe_name"]:
                                     for vulnerable_version in cpe_info["cpe_name"]:
+                                        cve['vulnerable_product'].append(vulnerable_version["cpe23Uri"])
                                         cve['vulnerable_configuration'].append(vulnerable_version["cpe23Uri"])
-                                        # If the entry is an application, add it to vulnerable_product
-                                        if vulnerable_version["cpe23Uri"].split(":")[2] == "a":
-                                            cve['vulnerable_product'].append(vulnerable_version["cpe23Uri"])
                                 else:
+                                    cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
                                     cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
-                                    if cpeuri["cpe23Uri"].split(":")[2] == "a":
-                                        cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
-
                         else:
                             # If the cpe_match did not have any of the version start/end modifiers,
                             # add the CPE string as it is.
-                            cve['vulnerable_configuration'].append(cpeuri['cpe23Uri'])
-                            # If the entry is an application, add it to vulnerable_product
-                            if cpeuri["cpe23Uri"].split(":")[2] == "a":
-                                cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
+                            cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
+                            cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
                     else:
                         query = {}
                         version_info = ""
@@ -167,8 +161,9 @@ def process_cve_item(item=None):
                         for cpeuri in child['cpe_match']:
                             if cpeuri['vulnerable']:
                                 cve['vulnerable_configuration'].append(cpeuri['cpe23Uri'])
+                                cve['vulnerable_product'].append(cpeuri['cpe23Uri'])
                             else:
-                                cve['non_vulnerable_configuration'].append(cpeuri['cpe23Uri'])
+                                cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
     if 'problemtype' in item['cve']:
         for problem in item['cve']['problemtype']['problemtype_data']:
             for cwe in problem['description']:   # NVD JSON not clear if we can get more than one CWE per CVE (until we take the last one) - NVD-CWE-Other??? list?

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -231,6 +231,7 @@ if __name__ == '__main__':
             print("database already populated")
         else:
             print("Database population started")
+            db.dropCollection("cve")
             for x in range(cveStartYear, year):
                 getfile = file_prefix + str(x) + file_suffix
                 try:

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -74,6 +74,11 @@ def get_cpe_info(cpeuri):
 
     return query, version_info
 
+def add_if_missing(cve, key, value):
+    if value not in cve[key]:
+        cve[key].append(value)
+    return cve
+
 def process_cve_item(item=None):
     if item is None:
         return None
@@ -115,27 +120,24 @@ def process_cve_item(item=None):
                 for cpeuri in cpe['cpe_match']:
                     if cpeuri['vulnerable']:
                         query, version_info = get_cpe_info(cpeuri)
-
                         if query != {}:
                             query["id"] = hashlib.sha1(cpeuri["cpe23Uri"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
                             cpe_info = db.getCPEVersionInformation(query)
-
                             if cpe_info:
                                 if cpe_info["cpe_name"]:
                                     for vulnerable_version in cpe_info["cpe_name"]:
-                                        cve['vulnerable_product'].append(vulnerable_version["cpe23Uri"])
-                                        cve['vulnerable_configuration'].append(vulnerable_version["cpe23Uri"])
+                                        cve = add_if_missing(cve, "vulnerable_product", vulnerable_version["cpe23Uri"])
+                                        cve = add_if_missing(cve, "vulnerable_configuration", vulnerable_version["cpe23Uri"])
                                 else:
-                                    cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
-                                    cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
+                                    cve = add_if_missing(cve, "vulnerable_product", cpeuri["cpe23Uri"])
+                                    cve = add_if_missing(cve, "vulnerable_configuration", cpeuri["cpe23Uri"])
                         else:
                             # If the cpe_match did not have any of the version start/end modifiers,
                             # add the CPE string as it is.
-                            cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
-                            cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
+                            cve = add_if_missing(cve, "vulnerable_product", cpeuri["cpe23Uri"])
+                            cve = add_if_missing(cve, "vulnerable_configuration", cpeuri["cpe23Uri"])
                     else:
-                        cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
-
+                        cve = add_if_missing(cve, "vulnerable_configuration", cpeuri["cpe23Uri"])
             if 'children' in cpe:
                 for child in cpe['children']:
                     if 'cpe_match' in child:
@@ -145,22 +147,21 @@ def process_cve_item(item=None):
                                 if query != {}:
                                     query["id"] = hashlib.sha1(cpeuri["cpe23Uri"].encode("utf-8") + version_info.encode("utf-8")).hexdigest()
                                     cpe_info = db.getCPEVersionInformation(query)
-
                                     if cpe_info:
                                         if cpe_info["cpe_name"]:
                                             for vulnerable_version in cpe_info["cpe_name"]:
-                                                cve['vulnerable_product'].append(vulnerable_version["cpe23Uri"])
-                                                cve['vulnerable_configuration'].append(vulnerable_version["cpe23Uri"])
+                                                cve = add_if_missing(cve, "vulnerable_product", vulnerable_version["cpe23Uri"])
+                                                cve = add_if_missing(cve, "vulnerable_configuration", vulnerable_version["cpe23Uri"])
                                         else:
-                                            cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
-                                            cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
+                                            cve = add_if_missing(cve, "vulnerable_product", cpeuri["cpe23Uri"])
+                                            cve = add_if_missing(cve, "vulnerable_configuration", cpeuri["cpe23Uri"])
                                 else:
                                     # If the cpe_match did not have any of the version start/end modifiers,
                                     # add the CPE string as it is.
-                                    cve['vulnerable_product'].append(cpeuri["cpe23Uri"])
-                                    cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
+                                    cve = add_if_missing(cve, "vulnerable_product", cpeuri["cpe23Uri"])
+                                    cve = add_if_missing(cve, "vulnerable_configuration", cpeuri["cpe23Uri"])
                             else:
-                                cve['vulnerable_configuration'].append(cpeuri["cpe23Uri"])
+                                cve = add_if_missing(cve, "vulnerable_configuration", cpeuri["cpe23Uri"])
     if 'problemtype' in item['cve']:
         for problem in item['cve']['problemtype']['problemtype_data']:
             for cwe in problem['description']:   # NVD JSON not clear if we can get more than one CWE per CVE (until we take the last one) - NVD-CWE-Other??? list?

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -25,10 +25,10 @@ import lib.DatabaseLayer as db
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 
-sources = [{'name': "cve",
-            'updater': "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_json.py"), "-u")},
-           {'name': "cpe",
+sources = [{'name': "cpe",
             'updater': "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_cpe_dictionary.py"), "-u")},
+           {'name': "cve",
+            'updater': "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_json.py"), "-u")},
            {'name': "cpeother",
             'updater': "{} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_cpe_other_dictionary.py"))}]
 
@@ -114,11 +114,11 @@ while (loop):
         if source['name'] is not "redis-cache-cpe":
             log('Starting ' + source['name'])
             before = nbelement(collection=source['name'])
-            if args.f and source['name'] is "cve":
-                updater = "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_json.py"), "-pa")
-                subprocess.Popen((shlex.split(updater))).wait()
-            elif args.f and source['name'] is "cpe":
+            if args.f and source['name'] is "cpe":
                 updater = "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_cpe_dictionary.py"), "-pa")
+                subprocess.Popen((shlex.split(updater))).wait()
+            elif args.f and source['name'] is "cve":
+                updater = "{} {} {}".format(sys.executable, os.path.join(runPath, "db_mgmt_json.py"), "-pa")
                 subprocess.Popen((shlex.split(updater))).wait()
             else:
                 subprocess.Popen((shlex.split(source['updater']))).wait()


### PR DESCRIPTION
With the new knowledge from issue #389 how the vulnerable_product field used to work, I fixed the logic and now all vulnerable products are added to the field and not only products with type "application". A warning was added to the help text in search.py -p parameter.

I also removed non_vulnerable_configuration field, because it makes no sense to exist. I thought it would contain the fields that are marked as not vulnerable in the JSON, but apparently not. Does someone know what is the point of this field?

Updating the CPE database was quite slow, and I realized that updating it the same way as the CVE does not work in this case, because in CVE we have a separate file for recently modified CVEs, so we only have to go through a fraction of the CVEs. In CPE feed, we only get the whole CPE database, so it is much faster just to drop the CPE database and reimport it.