### PR TITLE
Speed up bulk update (i.e. CPE update) operations.

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -18,6 +18,8 @@ from passlib.hash import pbkdf2_sha256
 from lib.Config import Configuration as conf
 from lib.ProgressBar import progressbar
 
+from pymongo import UpdateOne
+
 # Variables
 db=conf.getMongoConnection()
 colCVE=             db['cves']
@@ -79,11 +81,36 @@ def bulkInsert(collection, data):
     bulk.execute()
 
 def bulkUpdate(collection, data):
-  if len(data)>0:
-    bulk=db[collection].initialize_unordered_bulk_op()
-    for x in data:
-      bulk.find({'id': x['id']}).upsert().update({'$set': x})
-    bulk.execute()
+  if len(data)<1:
+    return
+
+  batch = []
+  count=1000
+  print("Beginning bulk update of " + str(len(data)) + " items.")
+  for d in data:
+    batch.append(
+      UpdateOne(
+        {"id": d["id"]},
+        {"$set" : d },
+        upsert = True
+      )
+    )
+    if len(batch) == 1000:
+      db[collection].bulk_write(batch)
+      print("Updated " + str(count) + "/" + str(len(data)) + " items.")
+      batch=[]
+      count+=1000
+  if len(batch)>0:
+      db[collection].bulk_write(batch)
+      count+=len(batch)
+      print("Updated " + str(count) + "/" + str(len(data)) + " items.")
+  print("Finished bulk update.")
+
+
+    #bulk=db[collection].initialize_unordered_bulk_op()
+    #for x in data: 
+    #  bulk.find({'id': x['id']}).upsert().update({'$set': x})
+    #bulk.execute()
     #jdt_NOTE: initialize_ordered_bulk_op(), initialize_unordered_bulk_op(), BulkOperationBuilder are deprecated, bulk_write() should be used instead
     #jdt_NOTE: test possible effects of changes on sbin/db_mgmt_ref.py, sbin/db_mgmt_capec.py, sbin/db_mgmt_cwe.py, sbin/db_mgmt_cpe_dictionary.py
     #requests = []


### PR DESCRIPTION
The bulk update was taking a considerable time (especially when updating CPEs). I switched the methods being used to the new operations. The ones being used were deprecated. 

More importantly I introduced a write flush after every 1,000 elements. That speeds up the update considerably.

The CPE update now completes in about 50 seconds on my system. Previously it aborted after about 15 minutes because my system ran out of memory.

If you want me to change the output to stdout (or anything else;) just leave a note.

EDIT: Oh yeah - and we have to make sure that users run the 'db_mgmt_create_index.py' script before updating the database the first time. The CPE collection needs to index on the 'id' field (not just the '_id' field). If mongo cannot look up the 'id' for the upsert in the index it will do a full collection scan for every item. That will take forever.