### PR TITLE
Fix JSON 1.0 versus 1.1 Error

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -52,7 +52,7 @@ class Configuration():
                'auth_load': './etc/auth.txt'
                }
     #jdt_NOTE: chceck if these default data sources are up to date
-    sources={'cve':        "https://nvd.nist.gov/feeds/json/cve/1.0/",
+    sources={'cve':        "https://nvd.nist.gov/feeds/json/cve/1.1/",
              'cpe':        "https://nvd.nist.gov/feeds/json/cpematch/1.0/nvdcpematch-1.0.json.zip",
              'cwe':        "https://cwe.mitre.org/data/xml/cwec_v3.1.xml.zip",
              'capec':      "https://capec.mitre.org/data/xml/capec_v3.0.xml",

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
                 print("Not modified")
                 sys.exit(0)
 
-        cpej = json.loads(f.read())
+        cpej = json.loads(f.read().decode('utf-8'))
         cpeList = []
         for cpeitem in cpej["matches"]:
             item = process_cpe_item(cpeitem)
@@ -107,7 +107,7 @@ if __name__ == '__main__':
             except:
                 sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL("cpe")))
 
-            cpej = json.loads(f.read())
+            cpej = json.loads(f.read().decode('utf-8'))
             cpeList = []
             for cpeitem in cpej["matches"]:
                 item = process_cpe_item(cpeitem)

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -41,7 +41,7 @@ args = argparser.parse_args()
 
 
 # init parts of the file names to enable looped file download
-file_prefix = "nvdcve-1.0-"
+file_prefix = "nvdcve-1.1-"
 file_suffix = ".json.gz"
 file_mod = "modified"
 file_rec = "recent"
@@ -239,7 +239,7 @@ if __name__ == '__main__':
                 except:
                     sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL('cve') + getfile))
 
-                cvej = json.loads(f.read())
+                cvej = json.loads(f.read().decode('utf-8'))
                 if cvej['CVE_data_type'] != 'CVE':
                     print('JSON data type is not CVE but {}'.format(cvej['CVE_data_type']))
                 for cveitem in cvej['CVE_Items']:


### PR DESCRIPTION
After changing the CVE repository in ./lib/Config.py to "https://nvd.nist.gov/feeds/json/cve/1.1/" and in sbin/db_mgmt_json.py the file_prefix to "nvdcve-1.1-" I got the error: "JSON error: the JSON object must be str, not 'bytes'".
This could be fixed by adding .decode('utf-8') to the f.read() method call in ./sbin/db_mgmt_cpe_dictionary.py, ./sbin/db_mgmt_cpe_dictionary.py and ./sbin/db_mgmt_json.py