### PR TITLE
 Typo - `access` spelled `acccess`

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -69,7 +69,7 @@ def insertCVE(cve):
 
 def updateCVE(cve):
   colCVE.update({"id": cve['id']}, {"$set": {"cvss": cve['cvss'], "summary": cve['summary'], "references": cve['references'], "impact": cve['impact'],
-                                             "vulnerable_product": cve["vulnerable_product"], "access": cve['acccess'],
+                                             "vulnerable_product": cve["vulnerable_product"], "access": cve['access'],
                                              "cwe": cve['cwe'], "vulnerable_configuration": cve['vulnerable_configuration'],
                                              "vulnerable_configuration_cpe_2_2": cve['vulnerable_configuration_cpe_2_2'], 'last-modified': cve['Modified']}})
 


### PR DESCRIPTION
Starting cve
Traceback (most recent call last):
  File "/cve-search/sbin/db_mgmt_json.py", line 202, in <module>
    db.updateCVE(item)
  File "/cve-search/sbin/../lib/DatabaseLayer.py", line 72, in updateCVE
    "vulnerable_product": cve["vulnerable_product"], "access": cve['acccess'],
KeyError: 'acccess'