### PR TITLE
notification bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
     #- "3.2"
-    - "3.3"
+    #- "3.3"
     - "3.4"
     - "3.5"
     - "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
     #- "3.2"
-    #- "3.3"
+    - "3.3"
     - "3.4"
     - "3.5"
     - "nightly"

--- a/sbin/db_notification.py
+++ b/sbin/db_notification.py
@@ -119,7 +119,7 @@ elif args.n:
         for cpe in r.smembers("c:" + org):
             if args.v:
                 print("CPE " + cpe)
-            for cve in searchcve(cpe=cpe):
+            for cve in searchcve(cpe=cpe)['results']:
                 knowncve.add(cve['id'])
         if r.exists("s:" + org):
             x = r.smembers("s:" + org)


### PR DESCRIPTION
Without this small fix I get the following error: 
```
$ ./sbin/db_notification.py -n
Traceback (most recent call last):
  File "./sbin/db_notification.py", line 123, in <module>
    knowncve.add(cve['id'])
TypeError: string indices must be integers

```