### PR TITLE
Add support for the latest CAPEC XML file version (3.2).

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -55,7 +55,7 @@ class Configuration():
     sources={'cve':        "https://nvd.nist.gov/feeds/json/cve/1.0/",
              'cpe':        "https://nvd.nist.gov/feeds/json/cpematch/1.0/nvdcpematch-1.0.json.zip",
              'cwe':        "https://cwe.mitre.org/data/xml/cwec_v3.1.xml.zip",
-             'capec':      "https://capec.mitre.org/data/xml/capec_v3.0.xml",
+             'capec':      "https://capec.mitre.org/data/xml/capec_v3.2.xml",
              'via4':       "https://www.cve-search.org/feeds/via4.json",
              'includecve': True, 'includecapec':  True, 'includemsbulletin': True,
              'includecpe': True, 'includecwe':    True, 'includevia4':       True}

--- a/sbin/db_mgmt_capec.py
+++ b/sbin/db_mgmt_capec.py
@@ -57,48 +57,48 @@ class CapecHandler(ContentHandler):
 
     def startElement(self, name, attrs):
 
-        if name == 'capec:Attack_Pattern_Catalog':
+        if name == 'Attack_Pattern_Catalog':
             self.Attack_Pattern_Catalog_tag = True
-        if name == 'capec:Attack_Patterns' and self.Attack_Pattern_Catalog_tag:
+        if name == 'Attack_Patterns' and self.Attack_Pattern_Catalog_tag:
             self.Attack_Patterns_tag = True
-        if name == 'capec:Attack_Pattern' and self.Attack_Patterns_tag:
+        if name == 'Attack_Pattern' and self.Attack_Patterns_tag:
             self.Attack_Pattern_tag = True
 
         if self.Attack_Pattern_tag:
             self.tag = name
-            if self.tag == 'capec:Attack_Pattern':
+            if self.tag == 'Attack_Pattern':
                 self.id = attrs.getValue('ID')
                 self.name = attrs.getValue('Name')
 
-            if self.tag == 'capec:Description':
+            if self.tag == 'Description':
                 self.Description_tag = True
-            if name == 'capec:Summary' and self.Description_tag:
+            if name == 'Summary' and self.Description_tag:
                 self.Summary_tag = True
-            if name == 'capec:Text' and self.Summary_tag:
+            if name == 'Text' and self.Summary_tag:
                 self.Text_tag = True
                 self.Summary_ch = ""
 
-            if self.tag == 'capec:Attack_Prerequisites':
+            if self.tag == 'Attack_Prerequisites':
                 self.Attack_Prerequisites_tag = True
-            if name == 'capec:Attack_Prerequisite' and self.Attack_Prerequisites_tag:
+            if name == 'Attack_Prerequisite' and self.Attack_Prerequisites_tag:
                 self.Attack_Prerequisite_tag = True
-            if name == 'capec:Text' and self.Attack_Prerequisite_tag:
+            if name == 'Text' and self.Attack_Prerequisite_tag:
                 self.Text_tag = True
                 self.Attack_Prerequisite_ch = ""
 
-            if self.tag == 'capec:Solutions_and_Mitigations':
+            if self.tag == 'Solutions_and_Mitigations':
                 self.Solutions_and_Mitigations_tag = True
-            if name == 'capec:Solution_or_Mitigation' and self.Solutions_and_Mitigations_tag:
+            if name == 'Solution_or_Mitigation' and self.Solutions_and_Mitigations_tag:
                 self.Solution_or_Mitigation_tag = True
-            if name == 'capec:Text' and self.Solution_or_Mitigation_tag:
+            if name == 'Text' and self.Solution_or_Mitigation_tag:
                 self.Text_tag = True
                 self.Solution_or_Mitigation_ch = ""
 
-            if self.tag == 'capec:Related_Weaknesses':
+            if self.tag == 'Related_Weaknesses':
                 self.Related_Weaknesses_tag = True
-            if name == 'capec:Related_Weakness' and self.Related_Weaknesses_tag:
+            if name == 'Related_Weakness' and self.Related_Weaknesses_tag:
                 self.Related_Weakness_tag = True
-            if name == 'capec:CWE_ID' and self.Related_Weakness_tag:
+            if name == 'CWE_ID' and self.Related_Weakness_tag:
                 self.CWE_ID_tag = True
                 self.CWE_ID_ch = ""
 
@@ -114,39 +114,39 @@ class CapecHandler(ContentHandler):
             self.CWE_ID_ch += ch
 
     def endElement(self, name):
-        if name == 'capec:Summary':
+        if name == 'Summary':
             if self.Summary_ch != "":
                 self.Summary_ch = ""
             self.Summary_tag = False
-        if name == 'capec:Attack_Prerequisite':
+        if name == 'Attack_Prerequisite':
             if self.Attack_Prerequisite_ch != "":
                 self.Attack_Prerequisite.append(self.Attack_Prerequisite_ch.rstrip())
             self.Attack_Prerequisite_tag = False
-        if name == 'capec:Solution_or_Mitigation':
+        if name == 'Solution_or_Mitigation':
             if self.Solution_or_Mitigation_ch != "":
                 self.Solution_or_Mitigation.append(self.Solution_or_Mitigation_ch.rstrip())
             self.Solution_or_Mitigation_tag = False
-        if name == 'capec:Related_Weakness':
+        if name == 'Related_Weakness':
             if self.CWE_ID_ch != "":
                 self.Related_Weakness.append(self.CWE_ID_ch.rstrip())
             self.Related_Weakness_tag = False
 
-        if name == 'capec:Description':
+        if name == 'Description':
             self.Description_tag = False
-        if name == 'capec:Attack_Prerequisites':
+        if name == 'Attack_Prerequisites':
             self.Attack_Prerequisites_tag = False
-        if name == 'capec:Solutions_and_Mitigations':
+        if name == 'Solutions_and_Mitigations':
             self.Solutions_and_Mitigations_tag = False
-        if name == 'capec:Related_Weaknesses':
+        if name == 'Related_Weaknesses':
             self.Related_Weaknesses_tag = False
 
-        if name == 'capec:Text':
+        if name == 'Text':
             if self.Summary_tag:
                 self.Summary.append(self.Summary_ch.rstrip())
             self.Text_tag = False
-        if name == 'capec:CWE_ID':
+        if name == 'CWE_ID':
             self.CWE_ID_tag = False
-        if name == 'capec:Attack_Pattern':
+        if name == 'Attack_Pattern':
             self.capec.append({'name': self.name, 'id': self.id, 'summary': '\n'.join(self.Summary), 'prerequisites': '\n'.join(self.Attack_Prerequisite), 'solutions': '\n'.join(self.Solution_or_Mitigation), 'related_weakness': self.Related_Weakness})
             self.Summary = []
             self.Attack_Prerequisite = []
@@ -154,32 +154,39 @@ class CapecHandler(ContentHandler):
             self.Related_Weakness = []
 
             self.Attack_Pattern_tag = False
-        if name == 'capec:Attack_Patterns':
+        if name == 'Attack_Patterns':
             self.Attack_Patterns_tag = False
-        if name == 'capec:Attack_Pattern_Catalog':
+        if name == 'Attack_Pattern_Catalog':
             self.Attack_Pattern_Catalog_tag = False
 
-# make parser
-parser = make_parser()
-ch = CapecHandler()
-parser.setContentHandler(ch)
-# check modification date
-try:
-    (f, r) = Configuration.getFeedData('capec')
-except:
-    sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL("capec")))
-i = db.getLastModified('capec')
-last_modified = parse_datetime(r.headers['last-modified'], ignoretz=True)
-if i is not None:
-    if last_modified == i:
-        print("Not modified")
-        sys.exit(0)
-# parse xml and store in database
-parser.parse(f)
-attacks=[]
-for attack in progressbar(ch.capec):
-    attacks.append(attack)
-db.bulkUpdate("capec", attacks)
+if __name__ == "__main__":
+    # Make a SAX2 XML parser
+    parser = make_parser()
+    ch = CapecHandler()
+    parser.setContentHandler(ch)
 
-#update database info after successful program-run
-db.setColUpdate('capec', last_modified)
+    # Retrieve CAPECs from the configuration's capec url
+    try:
+        print("[+] Getting CAPEC XML file")
+        (f, r) = Configuration.getFeedData('capec')
+    except Exception as e:
+        sys.exit("Cannot open url %s. Bad URL or not connected to the internet?"%(Configuration.getFeedURL("capec")))
+
+    db_last_modified = db.getLastModified('capec')
+    last_modified = parse_datetime(r.headers['last-modified'], ignoretz=True)
+    if db_last_modified is not None:
+        if last_modified == db_last_modified:
+            print("Not modified")
+            sys.exit(0)
+
+    # Parse XML and store in database
+    parser.parse(f)
+    attacks=[]
+    for attack in progressbar(ch.capec):
+        attacks.append(attack)
+
+    print("[+] %d attacks in XML file" % (len(attacks)))
+    db.bulkUpdate("capec", attacks)
+
+    # Update database info after successful program-run
+    db.setColUpdate('capec', last_modified)


### PR DESCRIPTION
This PR adds support for the latest CAPEC XML file version (3.2) (Issue #414). 
In the new CAPEC XML files, tags' names seem to be not prefixed by "capec:" anymore. 
The commit simply consists in:
- Changing the CAPEC XML file URL in Config.py (from 3.0 to 3.2)
- Removing occurrences of "capec:" in db_mgmt_capec.py.