### PR TITLE
Drop the `cves` (not the `cve`) collection when repopulating

### DIFF
--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -231,7 +231,7 @@ if __name__ == '__main__':
             print("database already populated")
         else:
             print("Database population started")
-            db.dropCollection("cve")
+            db.dropCollection("cves")
             for x in range(cveStartYear, year):
                 getfile = file_prefix + str(x) + file_suffix
                 try:


### PR DESCRIPTION
In `db_mgmt_json.py`, the non-existent `cve` collection is dropped on forced repopulation. This results in duplicate records for CVEs. I imagine the intent was to instead dropped the existent `cves` collection. This pull request makes it do just that.