### PR TITLE
Cve search 462

### DIFF
--- a/lib/Sources_process.py
+++ b/lib/Sources_process.py
@@ -227,7 +227,7 @@ class CVEDownloads(JSONFileHandler):
                     "vectorString"
                 ]
             else:
-                cve["cvss"] = float(5)
+                cve["cvss"] = None
         if "references" in item["cve"]:
             cve["references"] = []
             for ref in item["cve"]["references"]["reference_data"]:

--- a/sbin/db_ranking.py
+++ b/sbin/db_ranking.py
@@ -48,7 +48,7 @@ def findranking(cpe=None, loosy=True):
 
     if loosy:
         for x in cpe.split(":"):
-            if x is not "":
+            if x != "":
                 i = findRanking(x, regex=True)
             if i is None:
                 continue
@@ -67,7 +67,7 @@ def findranking(cpe=None, loosy=True):
 
 def removeranking(cpe=None):
 
-    if cpe is None or cpe is "":
+    if cpe is None or cpe == "":
         return False
 
     return removeRanking(cpe)


### PR DESCRIPTION
Syntax error warnings fixed and set default cvss value to None instead of 5 when importing new CVE's.

fix #462 