### PR TITLE
Config bug

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -28,7 +28,8 @@ runPath = os.path.dirname(os.path.realpath(__file__))
 
 class Configuration:
     ConfigParser = configparser.ConfigParser()
-    ConfigParser.read(os.path.join(runPath, "../etc/configuration.ini"))
+    ConfigParser.read([os.path.join(runPath, "../etc/configuration.ini"),
+                    os.path.join(runPath, "../etc/sources.ini")])
     default = {
         "redisHost": "localhost",
         "redisPort": 6379,
@@ -79,6 +80,11 @@ class Configuration:
         "includecwe": True,
         "includevia4": True,
     }
+    @classmethod
+    def reloadConfiguration(cls):
+        cls.ConfigParser.clear()
+        return cls.ConfigParser.read([os.path.join(runPath, "../etc/configuration.ini"),
+                    os.path.join(runPath, "../etc/sources.ini")])
 
     @classmethod
     def readSetting(cls, section, item, default):
@@ -358,8 +364,7 @@ class Configuration:
 
     @classmethod
     def getFeedURL(cls, source):
-        cls.ConfigParser.clear()
-        cls.ConfigParser.read(os.path.join(runPath, "../etc/sources.ini"))
+        cls.reloadConfiguration()
         return cls.readSetting("Sources", source, cls.sources.get(source, ""))
 
     @classmethod


### PR DESCRIPTION
When using a non-default setting for the mongodb host. An error will appear after the following command is run:
`python3 /opt/cve-search/sbin/db_mgmt_cpe_dictionary.py -p`
[error.txt](https://github.com/cve-search/cve-search/files/5360968/error.txt)

The downloadhandler will try to connect to the default configuration again.
This is caused by the getFeedURL() funtion in config.py. It clears the configuration and only reloads the sources.ini.

Therefore i added a new function "reloadConfiguration()" which reloads both config files, and called it in the "getFeedURL()" funciton.