### PR TITLE
fixing #494

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -37,6 +37,11 @@ colPlugUserSettings = db["plugin_user_settings"]
 hash_rounds = 8000
 salt_size = 10
 
+mongo_version = db.command('buildinfo')['versionArray']
+# to check if mongodb > 4.4 
+# if it is, then use allow_disk_use for optimized queries
+# to be removed in future with the conditional statements
+# and use allow_disk_use by default
 
 # Functions
 def sanitize(x):
@@ -198,15 +203,28 @@ def cvesForCPE(cpe, lax=False, vulnProdSearch=False, limit=0):
         cpe_regex = product
 
         if limit != 0:
-            cves = (
-                colCVE.find({cpe_searchField: {"$regex": cpe_regex}})
-                .limit(limit)
-                .sort([("Modified", pymongo.DESCENDING), ("cvss", pymongo.DESCENDING)])
-            )
+            if mongo_version > [4, 4]:
+                cves = (
+                    colCVE.find({cpe_searchField: {"$regex": cpe_regex}})
+                    .limit(limit)
+                    .sort([("Modified", pymongo.DESCENDING), ("cvss", pymongo.DESCENDING)])
+                    .allow_disk_use(True)
+                )
+            else:
+                cves = (
+                    colCVE.find({cpe_searchField: {"$regex": cpe_regex}})
+                    .limit(limit)
+                    .sort([("Modified", pymongo.DESCENDING), ("cvss", pymongo.DESCENDING)])
+                )
         else:
-            cves = colCVE.find({cpe_searchField: {"$regex": cpe_regex}}).sort(
+            if mongo_version > [4, 4]:
+                cves = colCVE.find({cpe_searchField: {"$regex": cpe_regex}}).sort(
                 "Modified", direction=pymongo.DESCENDING
-            )
+                ).allow_disk_use(True)
+            else:
+                cves = colCVE.find({cpe_searchField: {"$regex": cpe_regex}}).sort(
+                "Modified", direction=pymongo.DESCENDING
+                )
 
         i = 0
 
@@ -254,11 +272,19 @@ def cvesForCPE(cpe, lax=False, vulnProdSearch=False, limit=0):
 
         # default strict search
         if limit != 0:
-            cves = (
-                colCVE.find({cpe_searchField: {"$regex": cpe_regex_string}})
-                .limit(limit)
-                .sort("cvss", direction=pymongo.DESCENDING)
-            )
+            if mongo_version > [4, 4]:
+                cves = (
+                    colCVE.find({cpe_searchField: {"$regex": cpe_regex_string}})
+                    .limit(limit)
+                    .sort("cvss", direction=pymongo.DESCENDING)
+                    .allow_disk_use(True)
+                )
+            else:
+                cves = (
+                    colCVE.find({cpe_searchField: {"$regex": cpe_regex_string}})
+                    .limit(limit)
+                    .sort("cvss", direction=pymongo.DESCENDING)
+                )
         else:
             cves = colCVE.find({cpe_searchField: {"$regex": cpe_regex_string}})
 
@@ -338,11 +364,27 @@ def getCVEs(limit=False, query=[], skip=0, cves=None, collection=None):
     if type(cves) == list:
         query.append({"id": {"$in": cves}})
     if len(query) == 0:
-        cve = col.find().sort("Modified", -1).limit(limit).skip(skip)
+        if mongo_version > [4, 4]:
+            cve = col.find().sort("Modified", pymongo.DESCENDING).limit(limit
+                    ).skip(skip).allow_disk_use(True)
+        else:
+            cve = col.find().sort("Modified", pymongo.DESCENDING).limit(limit
+                    ).skip(skip)
     elif len(query) == 1:
-        cve = col.find(query[0]).sort("Modified", -1).limit(limit).skip(skip)
+        if mongo_version > [4, 4]:
+            cve = col.find(query[0]).sort("Modified", pymongo.DESCENDING).limit(limit
+                    ).skip(skip).allow_disk_use(True)
+        else:
+            cve = col.find(query[0]).sort("Modified", pymongo.DESCENDING).limit(limit
+                    ).skip(skip)
     else:
-        cve = col.find({"$and": query}).sort("Modified", -1).limit(limit).skip(skip)
+        if mongo_version > [4, 4]:
+            cve = col.find({"$and": query}).sort("Modified", pymongo.DESCENDING).limit(limit
+                    ).skip(skip).allow_disk_use(True)
+        else:
+            cve = col.find({"$and": query}).sort("Modified", pymongo.DESCENDING).limit(limit
+                    ).skip(skip)
+
     return {"results": sanitize(cve), "total": cve.count()}
 
 
@@ -351,7 +393,12 @@ def getCVEsNewerThan(dt):
 
 
 def getCVEIDs(limit=-1):
-    return [x["id"] for x in colCVE.find().limit(limit).sort("Modified", -1)]
+    if mongo_version > [4, 4]:
+        return [x["id"] for x in colCVE.find().limit(limit).sort("Modified", pymongo.DESCENDING)
+                    .allow_disk_use(True)
+                ]
+    else:
+        return [x["id"] for x in colCVE.find().limit(limit).sort("Modified", pymongo.DESCENDING)]
 
 
 def getCVE(id, collection=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Jinja2==2.11.2
 tqdm==4.48.2
 ijson==3.1.1
 jsonpickle
-PyMongo==3.10.1
+PyMongo==3.11.0
 Werkzeug
 https://github.com/marianoguerra/feedformatter/archive/master.zip
 pytest==6.0.2


### PR DESCRIPTION
- added `allow_disk_use` for mongoDB > 4.4
- changed -1 to pymongo.DESCENDING wherever required
- updated PyMongo to 3.11.0 to use `allow_disk_use`

PyMongo 3.11.0 is backwards compatible for PyMongo >= 2.9 however, this must be thoroughly tested for deprecation warnings before merging (https://pymongo.readthedocs.io/en/stable/changelog.html).