### PR TITLE
bug - "/api/cwe/<int:cwe_id>" always returns null

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -433,7 +433,7 @@ def getCWEs(cweid=None):
     if cweid is None:
         return sanitize(sorted(colCWE.find(), key=lambda k: int(k["id"])))
     else:
-        return sanitize(colCWE.find_one({"id": cweid}))
+        return sanitize(colCWE.find_one({"id": str(cweid)}))
 
 
 def getInfo(collection):

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -433,7 +433,7 @@ def getCWEs(cweid=None):
     if cweid is None:
         return sanitize(sorted(colCWE.find(), key=lambda k: int(k["id"])))
     else:
-        return sanitize(colCWE.find_one({"id": str(cweid)}))
+        return sanitize(colCWE.find_one({"id": cweid}))
 
 
 def getInfo(collection):

--- a/web/api.py
+++ b/web/api.py
@@ -85,7 +85,7 @@ class API:
             {"r": "/api/cvefor/<path:cpe>/<limit>", "m": ["GET"], "f": self.api_cvesFor},
             {"r": "/api/cve/<cveid>", "m": ["GET"], "f": self.api_cve},
             {"r": "/api/cwe", "m": ["GET"], "f": self.api_cwe},
-            {"r": "/api/cwe/<int:cwe_id>", "m": ["GET"], "f": self.api_cwe},
+            {"r": "/api/cwe/<cwe_id>", "m": ["GET"], "f": self.api_cwe},
             {"r": "/api/capec/<cweid>", "m": ["GET"], "f": self.api_capec},
             {"r": "/api/capec/show/<capecid>", "m": ["GET"], "f": self.api_capec_by_id},
             {"r": "/api/last", "m": ["GET"], "f": self.api_last},


### PR DESCRIPTION
There seems to be a bug in the api at "/api/cwe/<int:cwe_id>" route.
The API always returns null.
```
curl http://127.0.0.1:5000/api/cwe/20
null
```
This is caused because the getCWEs() function in the DatabaseLayer.py allows to search for integers instead of strings. while the id numbers are stored as strings in the mongo database.

```
curl http://127.0.0.1:5000/api/cwe/20
{
    "Description": "crash via multiple \".\" characters in file extensioncrash via multiple \".\" characters in file extension",
    "id": "20",
    "name": "Improper Input Validation",
    "related_weaknesses": [
        "707",
        "345",
        "22",
        "41",
        "74",
        "119",
        "770"
    ],
    "status": "Stable",
    "weaknessabs": "Class"
}
```