### PR TITLE
clear queues to prevent duplicates

### DIFF
--- a/lib/DownloadHandler.py
+++ b/lib/DownloadHandler.py
@@ -43,7 +43,8 @@ class DownloadHandler(ABC):
 
         self.queue = RedisQueue(name=self.feed_type)
 
-        self.file_queue = RedisQueue(name="files")
+        self.file_queue = RedisQueue(name=f"{self.feed_type}:files")
+        self.file_queue.clear()
 
         self.progress_bar = None
 

--- a/lib/Sources_process.py
+++ b/lib/Sources_process.py
@@ -131,7 +131,7 @@ class CPEDownloads(JSONFileHandler):
     def populate(self, **kwargs):
         self.logger.info("CPE Database population started")
 
-        RedisQueue(name=self.feed_type).clear()
+        self.queue.clear()
 
         dropCollection(self.feed_type.lower())
 
@@ -574,7 +574,7 @@ class CVEDownloads(JSONFileHandler):
 
         self.is_update = False
 
-        RedisQueue(name="CVES").clear()
+        self.queue.clear()
 
         dropCollection("cves")
 

--- a/lib/Sources_process.py
+++ b/lib/Sources_process.py
@@ -28,6 +28,7 @@ from lib.Toolkit import generate_title
 from lib.XMLFileHandler import XMLFileHandler
 from lib.content_handlers import CapecHandler, CWEHandler
 from lib.db_action import DatabaseAction
+from lib.redis_q import RedisQueue
 
 # init parts of the file names to enable looped file download
 file_prefix = "nvdcve-1.1-"
@@ -129,6 +130,9 @@ class CPEDownloads(JSONFileHandler):
 
     def populate(self, **kwargs):
         self.logger.info("CPE Database population started")
+
+        RedisQueue(name=self.feed_type).clear()
+
         dropCollection(self.feed_type.lower())
 
         DatabaseIndexer().create_indexes(collection="cpe")
@@ -569,6 +573,8 @@ class CVEDownloads(JSONFileHandler):
         )
 
         self.is_update = False
+
+        RedisQueue(name="CVES").clear()
 
         dropCollection("cves")
 

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -26,7 +26,6 @@ sys.path.append(os.path.join(runPath, ".."))
 
 from lib.Sources_process import CPEDownloads
 from lib.DatabaseLayer import getSize
-from lib.redis_q import RedisQueue
 
 # parse command line arguments
 argparser = argparse.ArgumentParser(
@@ -59,5 +58,4 @@ if __name__ == "__main__":
         if c > 0 and args.a is False:
             cpd.logger.info("Database already populated")
         else:
-            RedisQueue(name="cpe").clear()
             last_modified = cpd.populate()

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -26,6 +26,7 @@ sys.path.append(os.path.join(runPath, ".."))
 
 from lib.Sources_process import CPEDownloads
 from lib.DatabaseLayer import getSize
+from lib.redis_q import RedisQueue
 
 # parse command line arguments
 argparser = argparse.ArgumentParser(
@@ -58,4 +59,5 @@ if __name__ == "__main__":
         if c > 0 and args.a is False:
             cpd.logger.info("Database already populated")
         else:
+            RedisQueue(name="cpe").clear()
             last_modified = cpd.populate()

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -21,7 +21,6 @@ sys.path.append(os.path.join(runPath, ".."))
 
 from lib.Sources_process import CVEDownloads
 from lib.DatabaseLayer import getSize
-from lib.redis_q import RedisQueue
 
 
 # parse command line arguments
@@ -56,5 +55,4 @@ if __name__ == "__main__":
         if c > 0 and args.a is False:
             cvd.logger.info("database already populated")
         else:
-            RedisQueue(name="CVES").clear()
             last_modified = cvd.populate()

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -21,6 +21,7 @@ sys.path.append(os.path.join(runPath, ".."))
 
 from lib.Sources_process import CVEDownloads
 from lib.DatabaseLayer import getSize
+from lib.redis_q import RedisQueue
 
 
 # parse command line arguments
@@ -55,5 +56,5 @@ if __name__ == "__main__":
         if c > 0 and args.a is False:
             cvd.logger.info("database already populated")
         else:
-
+            RedisQueue(name="CVES").clear()
             last_modified = cvd.populate()


### PR DESCRIPTION
When the population process is aborted during the downloading of the files , the tasks remain the the redis queue , therefore when the population process is started again it will process the files from the previous job and the new files. This will result in duplicates.
This is visible on the last line of this output , 37 files are being processed while 19 files have been downloaded.
```
#./sbin/db_mgmt_json.py -p 
2020-12-09 21:20:43,319 - CVEDownloads - INFO     - CVE database population started
2020-12-09 21:20:43,320 - CVEDownloads - INFO     - Starting CVE database population starting from year: 2002
2020-12-09 21:20:43,418 - DatabaseIndexer - INFO     - Success to create index [('id', 1)] on cves
2020-12-09 21:20:43,436 - DatabaseIndexer - INFO     - Success to create index [('vulnerable_configuration', 1)] on cves
2020-12-09 21:20:43,448 - DatabaseIndexer - INFO     - Success to create index [('vulnerable_product', 1)] on cves
2020-12-09 21:20:43,465 - DatabaseIndexer - INFO     - Success to create index [('Modified', 1)] on cves
2020-12-09 21:20:43,483 - DatabaseIndexer - INFO     - Success to create index [('Published', 1)] on cves
2020-12-09 21:20:43,504 - DatabaseIndexer - INFO     - Success to create index [('last-modified', 1)] on cves
2020-12-09 21:20:43,521 - DatabaseIndexer - INFO     - Success to create index [('cvss', 1)] on cves
2020-12-09 21:20:43,537 - DatabaseIndexer - INFO     - Success to create index [('summary', 'text')] on cves
2020-12-09 21:20:43,552 - DatabaseIndexer - INFO     - Success to create index [('vendors', 1)] on cves
2020-12-09 21:20:43,566 - DatabaseIndexer - INFO     - Success to create index [('products', 1)] on cves
2020-12-09 21:20:43,580 - DatabaseIndexer - INFO     - Success to create index [('vulnerable_product_stems', 1)] on cves
2020-12-09 21:20:43,591 - DatabaseIndexer - INFO     - Success to create index [('vulnerable_configuration_stems', 1)] on cves
Downloading files: 100%|█████████████████████████████████████████████████████████████████████████| 19/19 [00:08<00:00,  2.29it/s]
Processing downloaded files:   0%|                                                            | 0/37 [00:00<?, ?it/s]
```
To fix this issue I added a line to clear the file queue after it is being created.

A similar issue occurs when the population process is interrupted during de processing of the downloaded files. Since the database actions are already in the Redis queue , they will be performed on next attempt to populate in addition to all the newly added actions.
Therefore I added a line to clear the queue before the population process is started.

Also i added the feed_type to the redis queue name, this prevents the cpe and CVES files to be mixed up.


