### PR TITLE
added via4 check in getSearchResults() function

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -441,8 +441,10 @@ def getSearchResults(search):
     result = {"data": []}
     regSearch = re.compile(re.escape(search), re.IGNORECASE)
     links = {"n": "Link", "d": []}
-    for vLink in getInfo("via4").get("searchables", []):
-        links["d"].extend(sanitize(colVIA4.find({vLink: {"$in": [regSearch]}})))
+    via4 = getInfo("via4")
+    if via4:
+        for vLink in via4.get("searchables", []):
+            links["d"].extend(sanitize(colVIA4.find({vLink: {"$in": [regSearch]}})))
 
     try:
         textsearch = {"n": "Text search", "d": getFreeText(search)}


### PR DESCRIPTION
When searching for cve in the webinterface and the via4 collection isn't populated, the following error appears.
Therefore I added a check in the getSearchResults() function in lib/DatabaseLayer.py to verify if there is any data.
```
Traceback (most recent call last)
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 2450, in wsgi_app
response = self.handle_exception(e)
File "/usr/local/lib/python3.7/dist-packages/flask_restx/api.py", line 639, in error_router
return original_handler(e)
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1867, in handle_exception
reraise(exc_type, exc_value, tb)
File "/usr/local/lib/python3.7/dist-packages/flask/_compat.py", line 39, in reraise
raise value
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 2447, in wsgi_app
response = self.full_dispatch_request()
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1952, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/usr/local/lib/python3.7/dist-packages/flask_restx/api.py", line 639, in error_router
return original_handler(e)
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1821, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/usr/local/lib/python3.7/dist-packages/flask/_compat.py", line 39, in reraise
raise value
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1950, in full_dispatch_request
rv = self.dispatch_request()
File "/usr/local/lib/python3.7/dist-packages/flask/app.py", line 1936, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/opt/cve-search/web/home/views.py", line 232, in freetext_search
result = getSearchResults(search)
File "/opt/cve-search/lib/DatabaseLayer.py", line 444, in getSearchResults
for vLink in getInfo("via4").get("searchables", []):
AttributeError: 'NoneType' object has no attribute 'get'
```
