### PR TITLE
Use http proxy in download handler

### DIFF
--- a/lib/DownloadHandler.py
+++ b/lib/DownloadHandler.py
@@ -305,6 +305,7 @@ class DownloadHandler(ABC):
         return wd, filename
 
     def download_site(self, url):
+        from lib.Config import Configuration as conf
 
         if url[:4] == "file":
             self.logger.info("Scheduling local hosted file: {}".format(url))
@@ -335,7 +336,8 @@ class DownloadHandler(ABC):
             self.logger.debug("Downloading from url: {}".format(url))
             session = self.get_session()
             try:
-                with session.get(url) as response:
+                with session.get(url, proxies={"http": conf.getProxy(),
+                                               "https": conf.getProxy()}) as response:
                     try:
                         self.last_modified = parse_datetime(
                             response.headers["last-modified"], ignoretz=True


### PR DESCRIPTION
If the HTTP proxy isn't set the download will work without it as usual.