### PR TITLE
Provide /browse endpoint to list product CPEs

### DIFF
--- a/lib/Query.py
+++ b/lib/Query.py
@@ -100,14 +100,17 @@ def apigetcve(api, cveid=None):
         return False
 
 
-def apibrowse(api, vendor=None):
+def apibrowse(api, vendor=None, product=None):
     url = urllib.parse.urljoin(api, "api/browse")
     with requests.Session() as session:
         if vendor is None:
             r = session.get(url)
-        else:
+        elif product is None:
             urlvendor = url + "/" + vendor
             r = session.get(urlvendor)
+        else:
+            urlproduct = url + "/" + vendor + "/" + product
+            r = session.get(urlproduct)
 
     if r.status_code == 200:
         return r.text

--- a/web/restapi/browse_vendor.py
+++ b/web/restapi/browse_vendor.py
@@ -1,9 +1,11 @@
 from flask_restx import Namespace, Resource, fields
 
 from lib.Query import getBrowseList
+from lib.Query import getVersionsOfProduct
 from web.restapi.cpe_convert import message
 
-api = Namespace("browse", description="Endpoints for vendor information", path="/")
+api = Namespace(
+    "browse", description="Endpoints for vendor information", path="/")
 
 
 browseList = api.model(
@@ -81,6 +83,25 @@ browseListVendor = api.model(
     },
 )
 
+browseListProduct = api.model(
+    "browseVersions",
+    {
+        "version": fields.List(
+            fields.String,
+            description="List with product CPEs",
+            example=[
+                "*:*:*:*:*:*:*:*",
+                "1.0:*:*:*:*:*:*:*",
+                "1.1:*:*:*:*:*:*:*",
+                "2.0:*:*:*:*:*:*:*",
+                "....",
+            ],
+        ),
+        "product": fields.String(description="Product name", example=".net_core",),
+        "vendor": fields.String(description="Product name", example=".microsoft",),
+    },
+)
+
 
 @api.route("/browse")
 @api.response(400, "Error processing request", model=message)
@@ -114,3 +135,26 @@ class BrowseAll(Resource):
         browseList = getBrowseList(vendor)
 
         return browseList
+
+
+@api.route("/browse/<vendor>/<product>")
+@api.response(400, "Error processing request", model=message)
+@api.response(500, "Server error", model=message)
+class BrowseProductVersions(Resource):
+    @api.marshal_with(browseListProduct)
+    def get(self, vendor, product):
+        """
+        List CPEs of product
+
+        Returns a list of CPEs of a specific product.
+        When the link is called, it enumerates the CPEs for said product.
+        """
+        browse_list = getVersionsOfProduct(product)
+
+        result = {
+            "vendor": vendor,
+            "product": product,
+            "version": browse_list,
+        }
+
+        return result

--- a/web/restapi/browse_vendor.py
+++ b/web/restapi/browse_vendor.py
@@ -98,7 +98,7 @@ browseListProduct = api.model(
             ],
         ),
         "product": fields.String(description="Product name", example=".net_core",),
-        "vendor": fields.String(description="Product name", example=".microsoft",),
+        "vendor": fields.String(description="Vendor name", example=".microsoft",),
     },
 )
 


### PR DESCRIPTION
The vendor isn't really required here, but it fits the current API style and represents the same functionality as the web interface.