### PR TITLE
Fix Regular Expression injection

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -238,7 +238,7 @@ def cvesForCPE(cpe, lax=False, vulnProdSearch=False, limit=0, strict_vendor_prod
                 if cpe_regex not in vc:
                     continue
 
-                re_from_start = re.compile("^.*{}:".format(cpe_regex))
+                re_from_start = re.compile("^.*{}:".format(re.escape(cpe_regex)))
                 cpe_version = re_from_start.sub("", vc)
 
                 # TODO: handle versions such as "1.1.3:p2"


### PR DESCRIPTION
The fact of not sanitizing user input appended to a regular expression may lead to a `Regular Expression Denegation of Service` by an attacker crafting a regular expression taking too much to load, or simply change the behaviour of the program.

Vulnerable code:

https://github.com/cve-search/cve-search/blob/e31d913b8e9cb83f3fcab3c06187029333e6bca8/lib/DatabaseLayer.py#L241

References:

[OWASP ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)