### PR TITLE
Correct installation order

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -26,18 +26,18 @@ Dependencies
 Installation
 ------------
 
-Install CVE-Search and its python dependencies:
-
-.. code-block:: bash
-
-    pip3 install -r requirements.txt
-
 Install system requirements:
 
 .. code-block:: bash
 
     # Install system dependencies by running
     xargs sudo apt-get install -y < requirements.system
+
+Install CVE-Search and its Python dependencies:
+
+.. code-block:: bash
+
+    pip3 install -r requirements.txt
 
 Install mongodb.
 


### PR DESCRIPTION
Because `python3` & `python3-pip` are part of `requirements.system`, the system requirements must be installed before installing CVE-Search and its Python dependencies.