### PR TITLE
Added endpoints to search for the CPE fields vendor, product and version

### DIFF
--- a/lib/Query.py
+++ b/lib/Query.py
@@ -25,6 +25,8 @@ from lib.Config import Configuration
 rankinglookup = True
 redisdb = Configuration.getRedisVendorConnection()
 
+SCAN_COUNT = 1000
+
 
 def findranking(cpe=None, loosy=True):
     i = None
@@ -169,3 +171,39 @@ def getBrowseList(vendor):
 def getVersionsOfProduct(product):
     p = redisdb.smembers("p:" + product)
     return sorted(list(p))
+
+
+def searchVendors(vendor_part):
+    vendor_iterator = redisdb.scan_iter(f"v:*{vendor_part}*", count=SCAN_COUNT)
+    vendor_list = []
+
+    for vendor in vendor_iterator:
+        vendor_list.append(vendor.replace("v:", ""))
+
+    return {
+        "vendor": vendor_list
+    }
+
+
+def searchProductsByVendor(vendor, product_part):
+    product_iterator = redisdb.sscan_iter(f"v:{vendor}", f"*{product_part}*", count=SCAN_COUNT)
+    product_list = []
+
+    for product in product_iterator:
+        product_list.append(product.replace("p:", ""))
+
+    return {
+        "product": product_list,
+        "vendor": vendor
+    }
+
+
+def searchVersionsByProduct(vendor, product, version_part):
+    version_iterator = redisdb.sscan_iter(f"p:{product}", f"*{version_part}*", count=SCAN_COUNT)
+    version_list = list(version_iterator)
+
+    return {
+        "version": version_list,
+        "product": product,
+        "vendor": vendor
+    }

--- a/web/restapi/__init__.py
+++ b/web/restapi/__init__.py
@@ -8,11 +8,12 @@ from .cwe import api as cwe_api
 from .capec import api as capec_api
 from .query import api as query_api
 from .browse_vendor import api as browse_api
+from .search_vendor import api as search_vendor_api
 from .admin import wl as wl_api
 from .admin import bl as bl_api
 from .auth import api as auth_api
 
-namespaces = [cpe_api, cve_api, cwe_api, capec_api, query_api, browse_api]
+namespaces = [cpe_api, cve_api, cwe_api, capec_api, query_api, browse_api, search_vendor_api]
 
 blueprint = Blueprint("api", __name__, url_prefix="/api")
 

--- a/web/restapi/search_vendor.py
+++ b/web/restapi/search_vendor.py
@@ -1,0 +1,103 @@
+from flask_restx import Resource, Namespace, fields
+
+from lib.Query import searchVendors, searchProductsByVendor, searchVersionsByProduct
+from web.restapi.cpe_convert import message
+
+api = Namespace(
+    "search-vendor", description="Endpoints to search vendor information by providing part strings.", path="/")
+
+search_vendor_model = api.model(
+    "browseList",
+    {
+        "vendor": fields.List(
+            fields.String,
+            description="List with vendor names matching the given part",
+            example=[
+                ".bbsoftware",
+                ".joomclan",
+                ".matteoiammarrone",
+                ".....",
+            ],
+        ),
+    },
+)
+
+
+@api.route("/search-vendor/<vendor_part>")
+@api.response(400, "Error processing request", model=message)
+@api.response(500, "Server error", model=message)
+class SearchVendors(Resource):
+    @api.marshal_with(search_vendor_model)
+    def get(self, vendor_part):
+        """
+        Search vendors
+
+        Returns a list of vendors that match the given part-string.
+        """
+        return searchVendors(vendor_part)
+
+
+search_product_by_vendor_model = api.model(
+    "browseListVendor",
+    {
+        "product": fields.List(
+            fields.String,
+            description="List with product names belonging to the given vendor that match the given part string",
+            example=[
+                ".net_core",
+                ".net_core_sdk",
+                ".net_framework",
+                "....",
+            ],
+        ),
+        "vendor": fields.String(description="Vendor name", example="microsoft", ),
+    },
+)
+
+
+@api.route("/search-vendor/<vendor>/<product_part>")
+@api.response(400, "Error processing request", model=message)
+@api.response(500, "Server error", model=message)
+class SearchProductsByVendor(Resource):
+    @api.marshal_with(search_product_by_vendor_model)
+    def get(self, vendor, product_part):
+        """
+        Search products by vendor
+
+        Returns a list of products that match the given vendor and part-string.
+        """
+        return searchProductsByVendor(vendor, product_part)
+
+
+search_version_by_product_model = api.model(
+    "browseVersions",
+    {
+        "version": fields.List(
+            fields.String,
+            description="List with versions belonging to the given product that match the given part string",
+            example=[
+                "*:*:*:*:*:*:*:*",
+                "1.0:*:*:*:*:*:*:*",
+                "1.1:*:*:*:*:*:*:*",
+                "2.0:*:*:*:*:*:*:*",
+                "....",
+            ],
+        ),
+        "product": fields.String(description="Product name", example=".net_core", ),
+        "vendor": fields.String(description="Vendor name", example=".microsoft", ),
+    },
+)
+
+
+@api.route("/search-vendor/<vendor>/<product>/<version_part>")
+@api.response(400, "Error processing request", model=message)
+@api.response(500, "Server error", model=message)
+class SearchVersionsByProduct(Resource):
+    @api.marshal_with(search_version_by_product_model)
+    def get(self, vendor, product, version_part):
+        """
+        Search CPEs by vendor and product.
+
+        Returns a list of CPEs that match the given vendor, product and version part-string.
+        """
+        return searchVersionsByProduct(vendor, product, version_part)


### PR DESCRIPTION
Background: At EXXETA we need to be able to search for specific vendors, products and versions to use it for an autocompletion feature. While we could access the redis database directly we think it fits in the cve-search API and might be useful to others.

If you agree, do you think the endpoint paths are fine?

Note: One thing that is still missing here are tests. `SCAN_COUNT` might be a bit high.

CC: @jweigelt-exx