### PR TITLE
Convert WORKER_SIZE to int

### DIFF
--- a/lib/DownloadHandler.py
+++ b/lib/DownloadHandler.py
@@ -111,7 +111,7 @@ class DownloadHandler(ABC):
         """
 
         worker_size = (
-            os.getenv("WORKER_SIZE")
+            int(os.getenv("WORKER_SIZE"))
             if os.getenv("WORKER_SIZE")
             else min(32, os.cpu_count() + 4)
         )


### PR DESCRIPTION
Convert WORKER_SIZE from ENV to int as it can cause issues when not converted (in CVE-Search-Docker, for example).