### PR TITLE
Search in 'vendors' and 'products' fields

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -453,7 +453,12 @@ def getSearchResults(search):
         textsearch = {"n": "Text search", "d": []}
         result["errors"] = ["textsearch"]
 
-    for collection in [links, textsearch]:
+    search = search.lower()
+
+    vendor_query = {"n": "Vendor", "d": getCVEs(query=[{"vendors": search.replace(" ", "")}])["results"]}
+    product_query = {"n": "Product", "d": getCVEs(query=[{"products": search.replace(" ", "_")}])["results"]}
+
+    for collection in [links, textsearch, vendor_query, product_query]:
         for item in collection["d"]:
             # Check if already in result data
             if not any(item["id"] == entry["id"] for entry in result["data"]):


### PR DESCRIPTION
Searching using only fulltext queries misses a lot of obvious matches (search for "trendmicro" or "trend micro" returns a lot less CVEs than it should (<150, when there are 300+ CVEs for Trend Micro).

This addition doesn't slow the query at all and makes the results more accurate.