### PR TITLE
Added backend filter validation and pre-filling of the filter form data

### DIFF
--- a/web/home/utils.py
+++ b/web/home/utils.py
@@ -222,7 +222,7 @@ def validateFilter(filter_params):
         return False
 
     # Require valid options for selections.
-    if filter_params['cvssSelect'] not in ['all', 'above', 'equals' 'below']:
+    if filter_params['cvssSelect'] not in ['all', 'above', 'equals', 'below']:
         return False
     if filter_params['cvssVersion'] not in ['V2', 'V3']:
         return False

--- a/web/home/utils.py
+++ b/web/home/utils.py
@@ -209,6 +209,48 @@ def filterUpdateField(data):
     return "\n".join(returnvalue)
 
 
+def validateFilter(filter_params):
+
+    # CVSS must be a number betreen 0 and 10.
+    try:
+        cvss = float(filter_params['cvss'])
+        if cvss > 10:
+            return False
+        if cvss < 0:
+            return False
+    except ValueError:
+        return False
+
+    # Require valid options for selections.
+    if filter_params['cvssSelect'] not in ['all', 'above', 'equals' 'below']:
+        return False
+    if filter_params['cvssVersion'] not in ['V2', 'V3']:
+        return False
+    if filter_params['rejectedSelect'] not in ['hide', 'show']:
+        return False
+    if filter_params['timeSelect'] not in ['all', 'from', 'until', 'between', 'outside']:
+        return False
+    if filter_params['timeTypeSelect'] not in ['Modified', 'Published', 'last-modified']:
+        return False
+
+    # Validate dates: required values and reasonable ranges.
+    if filter_params['timeSelect'] in ['from', 'between', 'outside']:
+        try:
+            startDate = parse_datetime(filter_params["startDate"])
+        except (ValueError, OverflowError) as e:
+            return False
+    if filter_params['timeSelect'] in ['until', 'between', 'outside']:
+        try:
+            endDate = parse_datetime(filter_params["endDate"])
+        except (ValueError, OverflowError) as e:
+            return False
+    if filter_params['timeSelect'] in ['between', 'outside']:
+        if startDate > endDate:
+            return False
+    
+    # None of the tests failed.
+    return True
+
 def adminInfo(output=None):
     return {"stats": getDBStats(True), "updateOutput": filterUpdateField(output)}
 

--- a/web/home/views.py
+++ b/web/home/views.py
@@ -275,7 +275,7 @@ def set_filter():
     if validateFilter(filter_params):
         logger.debug("Accepted filter parameters: {}".format(filter_params))
         DATATABLE_FILTER = filter_params
-        return "SET"
+        return DATATABLE_FILTER
     else:
         logger.debug("Rejected filter parameters: {}".format(filter_params))
         return "Invalid filter parameters", 400
@@ -283,20 +283,24 @@ def set_filter():
 @home.route("/reset_filter")
 def reset_filter():
     global DATATABLE_FILTER
-
     DATATABLE_FILTER = defaultFilters
+    return DATATABLE_FILTER
 
-    return "SET"
+
+@home.route("/filter_active")
+def filter_active():
+    global DATATABLE_FILTER
+
+    if DATATABLE_FILTER == defaultFilters:
+        return jsonify(False)
+    else:
+        return jsonify(True)
 
 
 @home.route("/get_filter")
 def get_filter():
     global DATATABLE_FILTER
-
-    if DATATABLE_FILTER == defaultFilters:
-        return jsonify(True)
-    else:
-        return jsonify(False)
+    return DATATABLE_FILTER
 
 
 @home.route("/fetch_cve_data", methods=["POST"])

--- a/web/home/views.py
+++ b/web/home/views.py
@@ -17,7 +17,7 @@ from lib.DatabaseLayer import (
 )
 from lib.LogHandler import AppLogger
 from . import home
-from .utils import defaultFilters, config_args, markCPEs, generate_full_query
+from .utils import defaultFilters, config_args, markCPEs, generate_full_query, validateFilter
 from ..helpers.server_side_datatables import ServerSideDataTable
 from ..run import app
 
@@ -272,12 +272,13 @@ def set_filter():
 
     filter_params = dict(request.json)
 
-    logger.debug("Received filter parameters: {}".format(filter_params))
-
-    DATATABLE_FILTER = filter_params
-
-    return "SET"
-
+    if validateFilter(filter_params):
+        logger.debug("Accepted filter parameters: {}".format(filter_params))
+        DATATABLE_FILTER = filter_params
+        return "SET"
+    else:
+        logger.debug("Rejected filter parameters: {}".format(filter_params))
+        return "Invalid filter parameters", 400
 
 @home.route("/reset_filter")
 def reset_filter():

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -45,10 +45,6 @@
 <script>
 function getFormData(top){
 
-    if (top !== "top") {
-      $('#filter-toggle').click();
-    }
-
     var form_elements = document.getElementById('filter').elements;
 
     value_dict = {};
@@ -65,17 +61,20 @@ function getFormData(top){
             data: JSON.stringify(value_dict),
             contentType: "application/json; charset=utf-8",
             dataType: "json",
-            success: function(response) {
-               //
-            },
-            error: function(xhr) {
-               //Do Something to handle error
-            },
-            complete: function(data) {
+            success: function(data) {
               var table = $('#CVEs').DataTable();
               table.ajax.reload();
-              $('#filter_off').addClass('d-none');
-              $('#filter_on').removeClass('d-none');
+              check_filter_active();
+              //$('#filter_off').addClass('d-none');
+              //$('#filter_on').removeClass('d-none');
+              $('#filter-toggle').click();
+            },
+            error: function(xhr) {
+              alert("Error occured while setting the filter.");
+              console.log(xhr.statusText + xhr.responseText);
+            },
+            complete: function() {
+              // Something to do always.
             }
         });
 }
@@ -85,16 +84,46 @@ function reset_filters() {
             url: "{{url_for('home.index')}}reset_filter",
             type: "get",
             success: function(response) {
-               //
-            },
-            error: function(xhr) {
-               //Do Something to handle error
-            },
-            complete: function(data) {
               var table = $('#CVEs').DataTable();
               table.ajax.reload();
-              $('#filter_off').removeClass('d-none');
-              $('#filter_on').addClass('d-none');
+              check_filter_active();
+              //$('#filter_off').removeClass('d-none');
+              //$('#filter_on').addClass('d-none');
+            },
+            error: function(xhr) {
+              alert("Error occured while resetting the filter.");
+              console.log(xhr.statusText + xhr.responseText);
+            },
+            complete: function() {
+              // Something to do always.
+            }
+        });
+}
+
+function check_filter_active() {
+  $.ajax({
+            url: "{{url_for('home.index')}}filter_active",
+            type: "get",
+            success: function(response) {
+              var table = $('#CVEs').DataTable();
+              table.ajax.reload();
+              console.log("filter active: " + response)
+              var isTrueSet = (response === true);
+              if (isTrueSet) {
+                  $('#filter_off').addClass('d-none');
+                  $('#filter_on').removeClass('d-none');
+              }
+              else {
+                  $('#filter_off').removeClass('d-none');
+                  $('#filter_on').addClass('d-none')
+              }
+            },
+            error: function(xhr) {
+              alert("Error occured while checking the filter status.");
+              console.log(xhr.statusText + xhr.responseText);
+            },
+            complete: function() {
+              // Something to do always.
             }
         });
 }
@@ -175,30 +204,7 @@ function ConvertDateTime(datetimestring) {
        });
        $('#CVEs').removeClass('d-none');
 
-       $.ajax({
-            url: "{{url_for('home.index')}}get_filter",
-            type: "get",
-            success: function(response) {
-               //
-            },
-            error: function(xhr) {
-               //
-            },
-            complete: function(data) {
-
-                var isTrueSet = (data.responseJSON === true);
-
-                if (isTrueSet) {
-                    $('#filter_off').removeClass('d-none');
-                    $('#filter_on').addClass('d-none');
-                }
-                else {
-                    $('#filter_off').addClass('d-none');
-                    $('#filter_on').removeClass('d-none');
-                }
-
-            }
-        });
+       check_filter_active();
 
   } );
 </script>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -69,7 +69,7 @@ function getFormData(top){
             },
             error: function(xhr) {
               alert("Error occured while setting the filter.");
-              console.log(xhr.statusText + xhr.responseText);
+              console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
               // Something to do always.
@@ -88,7 +88,7 @@ function reset_filters() {
             },
             error: function(xhr) {
               alert("Error occured while resetting the filter.");
-              console.log(xhr.statusText + xhr.responseText);
+              console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
               // Something to do always.
@@ -103,7 +103,6 @@ function check_filter_active() {
             success: function(response) {
               var table = $('#CVEs').DataTable();
               table.ajax.reload();
-              console.log("filter active: " + response)
               var isTrueSet = (response === true);
               if (isTrueSet) {
                   $('#filter_off').addClass('d-none');
@@ -117,7 +116,7 @@ function check_filter_active() {
             },
             error: function(xhr) {
               alert("Error occured while getting the filter status.");
-              console.log(xhr.statusText + xhr.responseText);
+              console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
               // Something to do always.
@@ -132,7 +131,6 @@ function update_filter_form() {
             contentType: "application/json; charset=utf-8",
             dataType: "json",
             success: function(response) {
-              console.log(response)
               $('#timeSelect').val(response.timeSelect);
               $('#startDate').val(response.startDate);
               $('#endDate').val(response.endDate);
@@ -143,8 +141,8 @@ function update_filter_form() {
               $('#cvss').val(response.cvss);
             },
             error: function(xhr) {
-              alert("Error occured while getting the filter.");
-              console.log(xhr.statusText + xhr.responseText);
+              alert("Error occured while getting the filter parameters.");
+              console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
               // Something to do always.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -65,8 +65,6 @@ function getFormData(top){
               var table = $('#CVEs').DataTable();
               table.ajax.reload();
               check_filter_active();
-              //$('#filter_off').addClass('d-none');
-              //$('#filter_on').removeClass('d-none');
               $('#filter-toggle').click();
             },
             error: function(xhr) {
@@ -87,8 +85,6 @@ function reset_filters() {
               var table = $('#CVEs').DataTable();
               table.ajax.reload();
               check_filter_active();
-              //$('#filter_off').removeClass('d-none');
-              //$('#filter_on').addClass('d-none');
             },
             error: function(xhr) {
               alert("Error occured while resetting the filter.");
@@ -112,6 +108,7 @@ function check_filter_active() {
               if (isTrueSet) {
                   $('#filter_off').addClass('d-none');
                   $('#filter_on').removeClass('d-none');
+                  update_filter_form();
               }
               else {
                   $('#filter_off').removeClass('d-none');
@@ -119,7 +116,34 @@ function check_filter_active() {
               }
             },
             error: function(xhr) {
-              alert("Error occured while checking the filter status.");
+              alert("Error occured while getting the filter status.");
+              console.log(xhr.statusText + xhr.responseText);
+            },
+            complete: function() {
+              // Something to do always.
+            }
+        });
+}
+
+function update_filter_form() {
+  $.ajax({
+            url: "{{url_for('home.index')}}get_filter",
+            type: "get",
+            contentType: "application/json; charset=utf-8",
+            dataType: "json",
+            success: function(response) {
+              console.log(response)
+              $('#timeSelect').val(response.timeSelect);
+              $('#startDate').val(response.startDate);
+              $('#endDate').val(response.endDate);
+              $('#timeTypeSelect').val(response.timeTypeSelect);
+              $('#cvssVersion').val(response.cvssVersion);
+              $('#cvssSelect').val(response.cvssSelect);
+              $('#rejectedSelect').val(response.rejectedSelect);
+              $('#cvss').val(response.cvss);
+            },
+            error: function(xhr) {
+              alert("Error occured while getting the filter.");
               console.log(xhr.statusText + xhr.responseText);
             },
             complete: function() {


### PR DESCRIPTION
Fixing bug #733 

- Added backend filter validation for Ajax `/set_filter`.
- Made `/get_filter` do what its name suggests and 
  - added `/filter_active` to do what it formerly did, but flipped the `true` and the `false` to be more descriptive.
- Made the frontend
  - respond accordingly if this validaton fails.
  - aware of the filter status through the new `/filter_active`.
  - pre-fill the filter form based on the current filter parameters through the altered `/get_filter`.