### PR TITLE
UX enhancements related to the previous fixes on bug #733

### DIFF
--- a/web/static/css/custom/filter.css
+++ b/web/static/css/custom/filter.css
@@ -22,3 +22,8 @@
   color: red;
   padding: 4px;
 }
+
+.active_filter_hilight {
+  font-weight: bold;
+  background-color: #ffc107;;
+}

--- a/web/static/css/custom/filter.css
+++ b/web/static/css/custom/filter.css
@@ -15,5 +15,10 @@
 }
 
 #cvssVersion {
-    margin-right: 25px;
+  margin-right: 25px;
+}
+
+#filter_warning {
+  color: red;
+  padding: 4px;
 }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -131,6 +131,7 @@ function update_filter_form() {
             contentType: "application/json; charset=utf-8",
             dataType: "json",
             success: function(response) {
+              // Make active filters selected.
               $('#timeSelect').val(response.timeSelect);
               $('#startDate').val(response.startDate);
               $('#endDate').val(response.endDate);
@@ -139,6 +140,14 @@ function update_filter_form() {
               $('#cvssSelect').val(response.cvssSelect);
               $('#rejectedSelect').val(response.rejectedSelect);
               $('#cvss').val(response.cvss);
+              // Hilight active select options.
+              $('#filterdiv option').removeClass('active_filter_hilight');
+              $('#timeSelect option[value=' + response.timeSelect + ']').addClass('active_filter_hilight')
+              $('#timeTypeSelect option[value=' + response.timeTypeSelect + ']').addClass('active_filter_hilight')
+              $('#cvssVersion option[value=' + response.cvssVersion + ']').addClass('active_filter_hilight')
+              $('#cvssSelect option[value=' + response.cvssSelect + ']').addClass('active_filter_hilight')
+              $('#rejectedSelect option[value=' + response.rejectedSelect + ']').addClass('active_filter_hilight')
+              // Reset any warnings.
               $('#filter_warning').text('');
             },
             error: function(xhr) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -65,10 +65,9 @@ function getFormData(top){
               var table = $('#CVEs').DataTable();
               table.ajax.reload();
               check_filter_active();
-              $('#filter-toggle').click();
             },
             error: function(xhr) {
-              alert("Error occured while setting the filter.");
+              $('#filter_warning').text('An error occured while setting the filter. Check the filter parameters.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
@@ -87,7 +86,7 @@ function reset_filters() {
               check_filter_active();
             },
             error: function(xhr) {
-              alert("Error occured while resetting the filter.");
+              $('#filter_warning').text('An error occured while resetting the filter.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
@@ -113,9 +112,10 @@ function check_filter_active() {
                   $('#filter_off').removeClass('d-none');
                   $('#filter_on').addClass('d-none')
               }
+              $('#filter_warning').text('');
             },
             error: function(xhr) {
-              alert("Error occured while getting the filter status.");
+              $('#filter_warning').text('An error occured while getting the filter status.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
@@ -139,9 +139,10 @@ function update_filter_form() {
               $('#cvssSelect').val(response.cvssSelect);
               $('#rejectedSelect').val(response.rejectedSelect);
               $('#cvss').val(response.cvss);
+              $('#filter_warning').text('');
             },
             error: function(xhr) {
-              alert("Error occured while getting the filter parameters.");
+              $('#filter_warning').text('An error occured while getting the filter parameters.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {

--- a/web/templates/subpages/filters.html
+++ b/web/templates/subpages/filters.html
@@ -131,7 +131,12 @@
         {% endfor %}
         {% endif %}
         <div class="row">
-          <button id="filter_send" class="btn btn-outline-warning button_filter" type="submit" value="Search">Filter </button>
+          <div class="col-md-1">
+            <button id="filter_send" class="btn btn-outline-warning button_filter" type="submit" value="Search">Filter </button>
+          </div>
+          <div class="col-md-10">
+            <p id="filter_warning"></p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
While fixing the bug #733 I left behind some JavaScript alerts that are not good for UX. With the commits on this pull request, I added an inline placement for these warnings (red text right next to the "Filter" button). Later, this could be used for the warnings generated by the client-side validation.

Also, the current filter options are highlighted in the drop-down menu to distinguish the currently selected (not yet applied) options from the actual filter state. It seems to work as intended on Chromium based browsers, but not on Firefox.

Please check whether you find these as improvements.