### PR TITLE
Client-side filter handling with cookies

### DIFF
--- a/web/home/views.py
+++ b/web/home/views.py
@@ -2,7 +2,7 @@ import logging
 import re
 from collections import defaultdict
 
-from flask import render_template, request, jsonify, url_for
+from flask import render_template, request, make_response, json, jsonify, url_for
 from flask_breadcrumbs import register_breadcrumb, default_breadcrumb_root
 
 from lib.CVEs import CveHandler
@@ -24,8 +24,6 @@ from ..run import app
 logging.setLoggerClass(AppLogger)
 
 logger = logging.getLogger(__name__)
-
-DATATABLE_FILTER = defaultFilters
 
 default_breadcrumb_root(home, ".")
 
@@ -268,51 +266,67 @@ def link(key=None, value=None):
 
 @home.route("/set_filter", methods=["POST"])
 def set_filter():
-    global DATATABLE_FILTER
+    try:
+        filter_params = dict(request.json)
+        if validateFilter(filter_params):
+            logger.debug("Accepted filter parameters: {}".format(filter_params))
+            resp = make_response(jsonify(True), 200)
+            resp.set_cookie('cve_filter', json.dumps(filter_params))
+        else:
+            logger.debug("Rejected filter parameters: {}".format(filter_params))
+            resp = make_response(jsonify(False), 400)
+    except TypeError:
+        resp = make_response(jsonify(False), 400)
+    return resp
 
-    filter_params = dict(request.json)
-
-    if validateFilter(filter_params):
-        logger.debug("Accepted filter parameters: {}".format(filter_params))
-        DATATABLE_FILTER = filter_params
-        return DATATABLE_FILTER
-    else:
-        logger.debug("Rejected filter parameters: {}".format(filter_params))
-        return "Invalid filter parameters", 400
 
 @home.route("/reset_filter")
 def reset_filter():
-    global DATATABLE_FILTER
-    DATATABLE_FILTER = defaultFilters
-    return DATATABLE_FILTER
+    resp = make_response(jsonify(defaultFilters), 200)
+    resp.set_cookie('cve_filter', '', expires=0)
+    return resp
 
 
 @home.route("/filter_active")
 def filter_active():
-    global DATATABLE_FILTER
+    try:
+        filter_params = dict(json.loads(request.cookies.get('cve_filter')))
+        if not validateFilter(filter_params):
+            filter_params = defaultFilters
+    except TypeError:
+        filter_params = defaultFilters
 
-    if DATATABLE_FILTER == defaultFilters:
-        return jsonify(False)
+    if filter_params == defaultFilters:
+        filter_active = False
     else:
-        return jsonify(True)
+        filter_active = True
+    return jsonify(filter_active)
 
 
 @home.route("/get_filter")
 def get_filter():
-    global DATATABLE_FILTER
-    return DATATABLE_FILTER
+    try:
+        filter_params = dict(json.loads(request.cookies.get('cve_filter')))
+        if not validateFilter(filter_params):
+            filter_params = defaultFilters
+    except TypeError:
+        filter_params = defaultFilters
+    return filter_params
 
 
 @home.route("/fetch_cve_data", methods=["POST"])
 def fetch_cvedata():
-    global DATATABLE_FILTER
+    try:
+        filter_params = dict(json.loads(request.cookies.get('cve_filter')))
+        if not validateFilter(filter_params):
+            filter_params = defaultFilters
+    except TypeError:
+        filter_params = defaultFilters
 
-    logger.debug("Current filters set to: {}".format(DATATABLE_FILTER))
-
-    if DATATABLE_FILTER == defaultFilters:
+    if filter_params == defaultFilters:
         ssd = ServerSideDataTable(request=request, backend=dbh.connection)
     else:
-        query_filters = generate_full_query(DATATABLE_FILTER)
+        query_filters = generate_full_query(filter_params)
         if len(query_filters) != 0:
             ssd = ServerSideDataTable(
                 request=request,

--- a/web/home/views.py
+++ b/web/home/views.py
@@ -15,15 +15,11 @@ from lib.DatabaseLayer import (
     getSearchResults,
     via4Linked,
 )
-from lib.LogHandler import AppLogger
+
 from . import home
 from .utils import defaultFilters, config_args, markCPEs, generate_full_query, validateFilter
 from ..helpers.server_side_datatables import ServerSideDataTable
 from ..run import app
-
-logging.setLoggerClass(AppLogger)
-
-logger = logging.getLogger(__name__)
 
 default_breadcrumb_root(home, ".")
 
@@ -269,11 +265,9 @@ def set_filter():
     try:
         filter_params = dict(request.json)
         if validateFilter(filter_params):
-            logger.debug("Accepted filter parameters: {}".format(filter_params))
             resp = make_response(jsonify(True), 200)
             resp.set_cookie('cve_filter', json.dumps(filter_params))
         else:
-            logger.debug("Rejected filter parameters: {}".format(filter_params))
             resp = make_response(jsonify(False), 400)
     except TypeError:
         resp = make_response(jsonify(False), 400)

--- a/web/static/css/custom/filter.css
+++ b/web/static/css/custom/filter.css
@@ -21,6 +21,8 @@
 #filter_warning {
   color: red;
   padding: 4px;
+  margin-top: 3px;
+  margin-bottom: 3px;
 }
 
 .active_filter_hilight {

--- a/web/static/js/custom/filter.js
+++ b/web/static/js/custom/filter.js
@@ -16,13 +16,14 @@ function timeSelectDisable(){
       document.getElementById('endDate').readOnly = false;
       document.getElementById('timeTypeSelect').readOnly = false;
       break;
-    case "between":
+    case "between":  // Fallthrough
     case "outside":
       document.getElementById('startDate').readOnly = false;
       document.getElementById('endDate').readOnly = false;
       document.getElementById('timeTypeSelect').readOnly = false;
   }
 }
+
 function cvssSelectDisable(){
   var selected = document.getElementById("cvssSelect").value;
   switch(selected){
@@ -32,4 +33,47 @@ function cvssSelectDisable(){
     default:
       document.getElementById('cvss').readOnly = false;
   }
+}
+
+function validateDates(){
+  var startDate = new Date(document.getElementById("startDate").value);
+  var endDate= new Date(document.getElementById("endDate").value);
+
+  var selected = document.getElementById("timeSelect").value;
+  switch(selected){
+    case "all":
+      break;
+    case "from":
+      if (!isValidDate(startDate)) {
+        setFilterError('Starting date is not set.');
+        return false
+      }
+      break;
+    case "until":
+      if (!isValidDate(endDate)) {
+        setFilterError('End date is not set.');
+        return false
+      }
+      break;
+    case "between":  // Fallthrough
+    case "outside":
+      if (isValidDate(startDate) && isValidDate(endDate)) {
+        if (startDate.getTime() > endDate.getTime()) {
+          setFilterError('End date before starting date.');
+          return false
+        }
+      } else {
+        setFilterError('Both dates must be set.');
+        return false
+      }
+  }
+  return true
+}
+
+function isValidDate(d) {
+  return d instanceof Date && !isNaN(d);
+}
+
+function setFilterError(text) {
+  $('#filter_warning').text(text);
 }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -65,7 +65,7 @@ function getFormData(top){
               check_filter_active();
             },
             error: function(xhr) {
-              $('#filter_warning').text('An error occured while setting the filter. Check the filter parameters.');
+              setFilterError('An error occured while setting the filter. Check the filter parameters.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
@@ -84,7 +84,7 @@ function reset_filters() {
               table.ajax.reload();
             },
             error: function(xhr) {
-              $('#filter_warning').text('An error occured while resetting the filter.');
+              setFilterError('An error occured while resetting the filter.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
@@ -110,11 +110,11 @@ function check_filter_active() {
                 $('#filter_off').removeClass('d-none');
                 $('#filter_on').addClass('d-none')
                 $('#filterdiv option').removeClass('active_filter_hilight');
+                setFilterError('');
               }
-              $('#filter_warning').text('');
             },
             error: function(xhr) {
-              $('#filter_warning').text('An error occured while getting the filter status.');
+              setFilterError('An error occured while getting the filter status.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
@@ -139,6 +139,8 @@ function update_filter_form() {
               $('#cvssSelect').val(response.cvssSelect);
               $('#rejectedSelect').val(response.rejectedSelect);
               $('#cvss').val(response.cvss);
+              cvssSelectDisable()
+              timeSelectDisable()
               // Hilight active select options.
               $('#filterdiv option').removeClass('active_filter_hilight');
               $('#timeSelect option[value=' + response.timeSelect + ']').addClass('active_filter_hilight')
@@ -147,10 +149,10 @@ function update_filter_form() {
               $('#cvssSelect option[value=' + response.cvssSelect + ']').addClass('active_filter_hilight')
               $('#rejectedSelect option[value=' + response.rejectedSelect + ']').addClass('active_filter_hilight')
               // Reset any warnings.
-              $('#filter_warning').text('');
+              setFilterError('');
             },
             error: function(xhr) {
-              $('#filter_warning').text('An error occured while getting the filter parameters.');
+              setFilterError('An error occured while getting the filter parameters.');
               console.log(xhr.statusText + ": " + xhr.responseText);
             },
             complete: function() {
@@ -236,6 +238,14 @@ function ConvertDateTime(datetimestring) {
        $('#CVEs').removeClass('d-none');
 
        check_filter_active();
+
+       // Reset the filter error if any of the inputs changes.
+       $("#filterdiv").on("change", "select", function () {
+        setFilterError('')
+       });
+       $("#filterdiv").on("change", "input[type='date']", function () {
+        setFilterError('')
+       });
 
   } );
 </script>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -62,8 +62,6 @@ function getFormData(top){
             contentType: "application/json; charset=utf-8",
             dataType: "json",
             success: function(data) {
-              var table = $('#CVEs').DataTable();
-              table.ajax.reload();
               check_filter_active();
             },
             error: function(xhr) {
@@ -81,9 +79,9 @@ function reset_filters() {
             url: "{{url_for('home.index')}}reset_filter",
             type: "get",
             success: function(response) {
+              check_filter_active();
               var table = $('#CVEs').DataTable();
               table.ajax.reload();
-              check_filter_active();
             },
             error: function(xhr) {
               $('#filter_warning').text('An error occured while resetting the filter.');
@@ -100,17 +98,18 @@ function check_filter_active() {
             url: "{{url_for('home.index')}}filter_active",
             type: "get",
             success: function(response) {
-              var table = $('#CVEs').DataTable();
-              table.ajax.reload();
               var isTrueSet = (response === true);
               if (isTrueSet) {
-                  $('#filter_off').addClass('d-none');
-                  $('#filter_on').removeClass('d-none');
-                  update_filter_form();
+                $('#filter_off').addClass('d-none');
+                $('#filter_on').removeClass('d-none');
+                update_filter_form();
+                var table = $('#CVEs').DataTable();
+                table.ajax.reload();
               }
               else {
-                  $('#filter_off').removeClass('d-none');
-                  $('#filter_on').addClass('d-none')
+                $('#filter_off').removeClass('d-none');
+                $('#filter_on').addClass('d-none')
+                $('#filterdiv option').removeClass('active_filter_hilight');
               }
               $('#filter_warning').text('');
             },
@@ -180,7 +179,7 @@ function ConvertDateTime(datetimestring) {
 </script>
 <script>
   $(document).ready(function() {
-       $('#CVEs').DataTable({
+    $('#CVEs').DataTable({
            "processing": true,
            "serverSide": true,
            "ajax": {

--- a/web/templates/subpages/filters.html
+++ b/web/templates/subpages/filters.html
@@ -19,7 +19,7 @@
 
 <div id="filterdiv" class="collapse">
 
-  <form method="POST" onsubmit="getFormData();return false" id="filter">
+  <form method="POST" onsubmit="if(validateDates()){getFormData()};return false" id="filter">
     <div class="card">
       <div class="card-body">
         {% if (current_user is defined and current_user.is_authenticated)or listLogin == False %}
@@ -94,7 +94,7 @@
                 <option value="equals">Equals</option>
                 <option value="below">Below</option>
               </select>
-              <input class="form-control" name="cvss" id="cvss" type="number" readOnly min="0" max="10" step="0.5" value="0"></input>
+              <input class="form-control" name="cvss" id="cvss" type="number" readOnly min="0" max="10" step="0.1" value="0"></input>
             </div>
           </div>
           <div class="col-md-1" id="labelRejected">


### PR DESCRIPTION
Client-side filter handling with cookies (#747) & client-side filter validation with a more responsive functionality.

- The `/set_filter`, instead of setting a global variable, validates the filter and adds the cookie.
- The `/reset_filter` unsets the cookie.
- The `/filter_active` checks the cookie state.
- The `/fetch_cve_data` performs the validation again, because the cookie can be tampered with or may have old data formats in case the filter functionality is upgraded to have more features. Any error at this point are consider unrecoverable. Therefore, this has the same outcome as the `/reset_filter`, and the cookie with invalid filter settings gets removed.
- Client-side validation for dates is added with corresponding warning messages.
- The inline warning messages are reset right after the user changes any of the selections. I find this better for UX, because now the user can see more clearly when new errors arise.
- The step for CVSS filter is changed from `0.5` to `0.1`, because this is the correct step in the data. This is good especially when searching vulnerabilities with the `equals` option.