### PR TITLE
Fix the server-side filter date validation

### DIFF
--- a/web/home/utils.py
+++ b/web/home/utils.py
@@ -245,14 +245,12 @@ def validateFilter(filter_params):
 
     # Validate dates: required values and reasonable ranges.
     if filter_params["timeSelect"] in ["from", "between", "outside"]:
-        try:
-            startDate = timestringTOdatetime(filter_params["startDate"])
-        except (ValueError, OverflowError) as e:
+        startDate = timestringTOdatetime(filter_params["startDate"])
+        if not startDate:
             return False
     if filter_params["timeSelect"] in ["until", "between", "outside"]:
-        try:
-            endDate = timestringTOdatetime(filter_params["endDate"])
-        except (ValueError, OverflowError) as e:
+        endDate = timestringTOdatetime(filter_params["endDate"])
+        if not endDate:
             return False
     if filter_params["timeSelect"] in ["between", "outside"]:
         if startDate > endDate:


### PR DESCRIPTION
On [commit a1a457d10f026d0a5acb7bc927ae89c4966ef8ca](https://github.com/cve-search/cve-search/commit/a1a457d10f026d0a5acb7bc927ae89c4966ef8ca#diff-d9554bb4f2f3328eba7695c033f44ee6c2184e317ea48dacd0417fe9dafd8722R249) the `parse_datetime()` from `dateutil.parser` was replace with internal `web.helpers.common.timestringTOdatetime()`. However, the date validation in `validateFilter()`, [as implemented originally](https://github.com/cve-search/cve-search/commit/39a7da57c6f14bfc770eb3635ddde9f1a5aab545), was depending on the [`ParserError`](https://dateutil.readthedocs.io/en/stable/parser.html#warnings-and-exceptions) (`ValueError`, and additional `OverflowError`) exceptions provided by the `parse_datetime()`. (I.e., the Ajax error from #733 had returned.)

Therefore, the `validateFilter()` was returning true even if the date wasn't set properly. With this pull request, the `validateFilter()` will co-operate with the expected results from `timestringTOdatetime()`.

Currently, the "Filter" button on the form performs a client-side validation whereas the "Filter" button on the filter ribbon is still depending on the server-side validation. Despite these buttons _should_ work equally, it makes testing the server-side validation easier.