### PR TITLE
Fix typo in production installation

### DIFF
--- a/docs/source/webgui/webgui.rst
+++ b/docs/source/webgui/webgui.rst
@@ -192,7 +192,7 @@ Configure cve-search as a UWSGI app listening on a unix socket, and enable the a
 
 .. code-block:: bash
 
-    sudo cat /opt/cve/cve-search/etc/wsgi.ini.sample /etc/uwsgi/apps-available/cve-search.ini
+    sudo cat /opt/cve/cve-search/etc/wsgi.ini.sample > /etc/uwsgi/apps-available/cve-search.ini
     
     sudo ln -s /etc/uwsgi/apps-available/cve-search.ini /etc/uwsgi/apps-enabled/
     
@@ -207,7 +207,7 @@ Disable NGINX's default config, and configure proxying connections to the uwsgi 
     
     sudo rm /etc/nginx/sites-enabled/default
     
-    sudo cat /opt/cve/cve-search/etc/nginx.conf.sample /etc/nginx/sites-available/cve-search.conf
+    sudo cat /opt/cve/cve-search/etc/nginx.conf.sample > /etc/nginx/sites-available/cve-search.conf
     
     sudo ln -s /etc/nginx/sites-available/cve-search.conf /etc/nginx/sites-enabled/
 


### PR DESCRIPTION
Added missing redirects `>` to the `cat` commands in the instructions for production installation