### PR TITLE
Improve logging: config & fault tolerance (#774)

### DIFF
--- a/lib/LogHandler.py
+++ b/lib/LogHandler.py
@@ -30,12 +30,11 @@ class HelperLogger(logging.Logger):
 
     """
 
-    runPath = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-
-    logPath = os.path.join(runPath, "log")
-
-    if not os.path.exists(logPath):
-        os.makedirs(logPath)
+    # Logging state variables for fault tolerance; reference as "static" with 'HelperLogger.variableName'.
+    testedLogFile = False
+    testedUpdateLogFile = False
+    failedLogFile = False
+    failedUpdateLogFile = False
 
     config = Configuration()
 
@@ -158,6 +157,28 @@ class HelperLogger(logging.Logger):
 
         return super(HelperLogger, self).critical(msg, *args, **kwargs)
 
+    @staticmethod
+    def testLogging(log):
+        """
+        Static method for creating missing log directories and testing log operation.
+
+        Returns True if logging is possible and False on any failure.
+
+        :param log: Path to the log file to test/create.
+        :type log: str (or os.PathLike object)
+        """
+        logFile = os.path.realpath(log)
+        logPath = os.path.dirname(logFile)
+        try:
+            if not os.path.exists(logPath):
+                os.makedirs(logPath)
+            with open(logFile, 'a'):
+                os.utime(logFile, None)
+        except:
+            print("Warning! Could not write log to {}. Disabling temporarily.".format(logFile))
+            return False
+        return True
+
 
 class AppLogger(HelperLogger):
     def __init__(self, name, level=logging.NOTSET):
@@ -167,14 +188,20 @@ class AppLogger(HelperLogger):
             "%(asctime)s - %(name)-8s - %(levelname)-8s - %(message)s"
         )
 
-        crf = RotatingFileHandler(
-            filename=self.config.getLogfile(),
-            maxBytes=self.config.getMaxLogSize(),
-            backupCount=self.config.getBacklog(),
-        )
-        crf.setLevel(logging.DEBUG)
-        crf.setFormatter(formatter)
-        self.addHandler(crf)
+        if self.config.getLogging() and not HelperLogger.testedLogFile:
+            if not HelperLogger.testLogging(self.config.getLogfile()):
+                HelperLogger.failedLogFile = True
+            HelperLogger.testedLogFile = True
+
+        if self.config.getLogging() and not HelperLogger.failedLogFile:
+            crf = RotatingFileHandler(
+                filename=self.config.getLogfile(),
+                maxBytes=self.config.getMaxLogSize(),
+                backupCount=self.config.getBacklog(),
+            )
+            crf.setLevel(logging.DEBUG)
+            crf.setFormatter(formatter)
+            self.addHandler(crf)
 
         # syslog_formatter = logging.Formatter(
         #     "%(asctime)s [%(hostname)s] - %(name)-8s - %(levelname)-8s - %(message)s"
@@ -200,11 +227,17 @@ class UpdateHandler(HelperLogger):
             "%(asctime)s - %(name)-8s - %(levelname)-8s - %(message)s"
         )
 
-        crf = RotatingFileHandler(
-            filename=self.config.getUpdateLogFile(),
-            maxBytes=self.config.getMaxLogSize(),
-            backupCount=self.config.getBacklog(),
-        )
-        crf.setLevel(logging.DEBUG)
-        crf.setFormatter(formatter)
-        self.addHandler(crf)
+        if self.config.getLogging() and not HelperLogger.testedUpdateLogFile:
+            if not HelperLogger.testLogging(self.config.getUpdateLogFile()):
+                HelperLogger.failedUpdateLogFile = True
+            HelperLogger.testedUpdateLogFile = True
+
+        if self.config.getLogging() and not HelperLogger.failedUpdateLogFile:
+            crf = RotatingFileHandler(
+                filename=self.config.getUpdateLogFile(),
+                maxBytes=self.config.getMaxLogSize(),
+                backupCount=self.config.getBacklog(),
+            )
+            crf.setLevel(logging.DEBUG)
+            crf.setFormatter(formatter)
+            self.addHandler(crf)


### PR DESCRIPTION
Fixes the bug described in issue #774:

- Disables file based logging if `Logging: False` is set in `[Logging]` section of `./etc/configuration.ini`.
- Tries to create missing directories and files configured in `Logfile` and `Updatelogfile`.
  - Does not care about the existence of `./log` if it is not used. :)
- If writing to a log file fails, temporarily disables that log.
  - The tests are performed only once every time a script utilizing the `./lib/LogHandler.py` is run.
  - `AppLogger` & `UpdateHandler` triggers the corresponding test independently.
