### PR TITLE
Update searching process, if we do not know one of CPE element.

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -297,6 +297,8 @@ def cvesForCPE(
 
             cpe_regex = re.escape(re.sub(remove_trailing_regex_stars, "", cpe_regex))
 
+            cpe_regex = cpe_regex.replace("\\:\\*\\:", "\\:[^:]+\\:")
+
             cpe_regex_string = r"^{}:".format(cpe_regex)
         else:
             # more general search on same field; e.g. microsoft:windows_7


### PR DESCRIPTION
For example NVD service return results, if we don't know vendor:
`https://services.nvd.nist.gov/rest/json/cpes/1.0/?addOns=cves&includeDeprecated=false&cpeMatchString=cpe:2.3:a:*:openssl:1.1.1h`

With this fix cve-search will return same results:
`http://localhost:5000/api/cvefor/cpe:2.3:a:*:openssl:1.1.1h`

Without this fix nothing will be returned.