### PR TITLE
Database connectivity using MONGODB+SRV connection string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ etc/plugins.txt
 venv
 .coverage
 !/web/plugins/
+
+dump.rdb

--- a/.talismanrc
+++ b/.talismanrc
@@ -1,0 +1,4 @@
+fileignoreconfig:
+- filename: lib/Config.py
+  checksum: 5af001a1c11abbd8d146f32e28764a9b6e151a975a5079da9502183d18a4cbfe
+version: ""

--- a/docs/source/database/database.rst
+++ b/docs/source/database/database.rst
@@ -34,6 +34,25 @@ This consists of two steps and one optional step.
 
 .. _pop_db:
 
+Connecting to MongoDB
+---------------------
+
+MongoDB has two possible syntax for connecting to the database.
+
+* `mongodb://` - Default
+* `mongodb+srv://`
+
+The default syntax allows for connectivity to a single host or a replica set.  The SRV syntax
+allows for connecting using a  single DNS hostname which seeds multiple hosts in a replica set.
+The SRV DNS record contains all of the details required for connecting to any server contained
+in a replia set, even if one of the nodes is unavailable.
+
+To enable the SRV scheme, set the variable `DnsSrvRecord` to `True` in the configuration.ini file.
+For more information, read `MongoDB 3.6: Here to SRV you with easier replica set connections <https://www.mongodb.com/developer/article/srv-connection-strings/>`.
+
+*Note:* MongoDB Atlas requires the use of the SRV syntax.
+
+
 Populating the database
 -----------------------
 

--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -11,6 +11,9 @@ RefDB: 12
 Host: localhost
 Port: 27017
 DB: cvedb
+Username:
+Password:
+DnsSrvRecord: False
 PluginName: mongodb
 
 [dbmgt]

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -47,6 +47,7 @@ class Configuration:
         "mongoDB": "cvedb",
         "mongoUsername": "",
         "mongoPassword": "",
+        "mongoSrv": False,
         "DatabasePluginName": "mongodb",
         "flaskHost": "127.0.0.1",
         "flaskPort": 5000,
@@ -132,6 +133,7 @@ class Configuration:
 
     @classmethod
     def getMongoConnection(cls):
+        mongoSrv = cls.readSetting("Database", "DnsSrvRecord", cls.default["mongoSrv"])
         mongoHost = cls.readSetting("Database", "Host", cls.default["mongoHost"])
         mongoPort = cls.readSetting("Database", "Port", cls.default["mongoPort"])
         mongoDB = cls.getMongoDB()
@@ -141,7 +143,14 @@ class Configuration:
         mongoPassword = urllib.parse.quote(
             cls.readSetting("Database", "Password", cls.default["mongoPassword"])
         )
-        if mongoUsername and mongoPassword:
+        if mongoUsername and mongoPassword and mongoSrv is True:
+            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority".format(
+                username=mongoUsername,
+                password=mongoPassword,
+                host=mongoHost,
+                db=mongoDB
+            )
+        elif mongoUsername and mongoPassword:
             mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}".format(
                 username=mongoUsername,
                 password=mongoPassword,

--- a/lib/DatabasePlugins/mongodb.py
+++ b/lib/DatabasePlugins/mongodb.py
@@ -15,7 +15,7 @@ from lib.Config import Configuration
 
 config = Configuration()
 
-
+DNSSRV = config.readSetting("Database", "DnsSrvRecord", config.default["mongoSrv"])
 HOST = config.readSetting("Database", "Host", config.default["mongoHost"])
 PORT = config.readSetting("Database", "Port", config.default["mongoPort"])
 DATABASE = config.getMongoDB()
@@ -34,13 +34,26 @@ class MongoPlugin(DatabasePluginBase):
         """
         super().__init__()
 
-        if USERNAME and PASSWORD:
+        if USERNAME and PASSWORD and DNSSRV is True:
+            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority".format(
+                username=USERNAME,
+                password=PASSWORD,
+                host=HOST,
+                db=DATABASE
+            )
+        elif USERNAME and PASSWORD:
             mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}".format(
-                username=USERNAME, password=PASSWORD, host=HOST, port=PORT, db=DATABASE
+                username=USERNAME,
+                password=PASSWORD,
+                host=HOST,
+                port=PORT,
+                db=DATABASE
             )
         else:
             mongoURI = "mongodb://{host}:{port}/{db}".format(
-                host=HOST, port=PORT, db=DATABASE
+                host=HOST,
+                port=PORT,
+                db=DATABASE
             )
 
         connect = pymongo.MongoClient(mongoURI, connect=False)
@@ -49,11 +62,7 @@ class MongoPlugin(DatabasePluginBase):
         self.user_store = connect[DATABASE]["mgmt_users"]
 
         for each in self.connection.list_collection_names():
-            setattr(
-                self,
-                "store_{}".format(each),
-                Collection(database=self.connection, name=each),
-            )
+            setattr(self, f"store_{each}", Collection(database=self.connection, name=each))
 
     def create_schema(self, **kwargs):
         pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ ansicolors==1.1.8
 nltk==3.6.5
 nested-lookup==0.2.23
 oauthlib==3.1.1
+dnspython==2.1.0


### PR DESCRIPTION
Some MongoDB deployments may require the use of the `mongodb+srv://` connection string, which in turn generates a DNS seed list containing all of the MongoDB servers in a cluster and their respective ports.  This allows rotating servers without having to update clients.

This PR adds the following:

* Added feature to use mongodb+srv URI records in mongodb plugin. 
* Added URI configuration options in Config.py. 
* Updated sample configuration to include ability to enable mongodb-srv URI. 
* Added username and password to the sample configuration as it was not clear how these variables are set.
* Added dnspython to pip requirements.txt, as pymongo requires this package to query and resolve DNS.
* Updating database documentation to explain how to use the new configuration options for SRV syntax.