### PR TITLE
Add authentication database variables

### DIFF
--- a/docs/source/database/database.rst
+++ b/docs/source/database/database.rst
@@ -52,6 +52,14 @@ For more information, read `MongoDB 3.6: Here to SRV you with easier replica set
 
 *Note:* MongoDB Atlas requires the use of the SRV syntax.
 
+Database User Authentication
+----------------------------
+
+When passing a username and password, CVE-Search submits the values against the default `admin` 
+database. If the authentication information is stored in a database other than `admin`, 
+authentication attempts will fail.
+
+To change the default authentiation database, set the variable `AuthDB` in the configuration.ini file.
 
 Populating the database
 -----------------------

--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -14,6 +14,7 @@ DB: cvedb
 Username:
 Password:
 DnsSrvRecord: False
+AuthDB: admin
 PluginName: mongodb
 
 [dbmgt]

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -48,6 +48,7 @@ class Configuration:
         "mongoUsername": "",
         "mongoPassword": "",
         "mongoSrv": False,
+        "mongoAuth": "admin",
         "DatabasePluginName": "mongodb",
         "flaskHost": "127.0.0.1",
         "flaskPort": 5000,
@@ -136,6 +137,7 @@ class Configuration:
         mongoSrv = cls.readSetting("Database", "DnsSrvRecord", cls.default["mongoSrv"])
         mongoHost = cls.readSetting("Database", "Host", cls.default["mongoHost"])
         mongoPort = cls.readSetting("Database", "Port", cls.default["mongoPort"])
+        mongoAuth = cls.readSetting("Database", "AuthDB", cls.default["mongoAuth"])
         mongoDB = cls.getMongoDB()
         mongoUsername = urllib.parse.quote(
             cls.readSetting("Database", "Username", cls.default["mongoUsername"])
@@ -144,19 +146,21 @@ class Configuration:
             cls.readSetting("Database", "Password", cls.default["mongoPassword"])
         )
         if mongoUsername and mongoPassword and mongoSrv is True:
-            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority".format(
+            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?authSource={auth}&retryWrites=true&w=majority".format(
                 username=mongoUsername,
                 password=mongoPassword,
                 host=mongoHost,
-                db=mongoDB
+                db=mongoDB,
+                auth=mongoAuth
             )
         elif mongoUsername and mongoPassword:
-            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}".format(
+            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}?authSource={auth}".format(
                 username=mongoUsername,
                 password=mongoPassword,
                 host=mongoHost,
                 port=mongoPort,
                 db=mongoDB,
+                auth=mongoAuth
             )
         else:
             mongoURI = "mongodb://{host}:{port}/{db}".format(

--- a/lib/DatabasePlugins/mongodb.py
+++ b/lib/DatabasePlugins/mongodb.py
@@ -18,6 +18,7 @@ config = Configuration()
 DNSSRV = config.readSetting("Database", "DnsSrvRecord", config.default["mongoSrv"])
 HOST = config.readSetting("Database", "Host", config.default["mongoHost"])
 PORT = config.readSetting("Database", "Port", config.default["mongoPort"])
+AUTH = config.readSetting("Database", "AuthDB", config.default["mongoAuth"])
 DATABASE = config.getMongoDB()
 USERNAME = urllib.parse.quote(
     config.readSetting("Database", "Username", config.default["mongoUsername"])
@@ -35,19 +36,21 @@ class MongoPlugin(DatabasePluginBase):
         super().__init__()
 
         if USERNAME and PASSWORD and DNSSRV is True:
-            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?retryWrites=true&w=majority".format(
+            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?authSource={auth}&retryWrites=true&w=majority".format(
                 username=USERNAME,
                 password=PASSWORD,
                 host=HOST,
-                db=DATABASE
+                db=DATABASE,
+                auth=AUTH
             )
         elif USERNAME and PASSWORD:
-            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}".format(
+            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}?authSource={auth}".format(
                 username=USERNAME,
                 password=PASSWORD,
                 host=HOST,
                 port=PORT,
-                db=DATABASE
+                db=DATABASE,
+                auth=AUTH
             )
         else:
             mongoURI = "mongodb://{host}:{port}/{db}".format(


### PR DESCRIPTION
Fixes an issue when using username and passwords against a mongodb server.  When attempting to authenticate, it throws an error. The error was verified by capturing the connection string and testing it against the MongoDB Shell tool, which generates the same `Authentication failed` error:

```
pymongo.errors.OperationFailure: Authentication failed., full error: {'ok': 0.0, 'errmsg': 'Authentication failed.', 'code': 18, 'codeName': 'AuthenticationFailed'}
```

To resolve this issue, the `authSource` variable should be passed pointing to the authentication database, which is `admin` by default.

Before the update:
```
mongodb://root:example@localhost:27017/cvedb
```

After the PR:
```
mongodb://root:example@localhost:27017/cvedb?authSource=admin
```

This PR changes the following:
* Adds the `authSource` variable to the `config.py` file.
* Adds the `authSource` variable to the `mongodb.py` file.
* Adds the variable `AuthDB` to the `configuration.ini.sample` file.
* Sets the default `authSource` to the `admin` database.
* Updates the documentation to explain why you may want to change the `authSource` and where to update the variable in the confiiguration.ini file.