### PR TITLE
Configurable DownloadMaxWorkers (#890)

### DIFF
--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -17,6 +17,9 @@ DnsSrvRecord: False
 AuthDB: admin
 PluginName: mongodb
 
+[Download]
+MaxWorkers: 10
+
 [dbmgt]
 Tmpdir: ./tmp/
 

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -404,9 +404,16 @@ class Configuration:
     # Download Max Workers
     @classmethod
     def getDownloadMaxWorkers(cls):
-        return cls.readSetting(
+        maxWorkers = cls.readSetting(
             "Download", "MaxWorkers", cls.default["DownloadMaxWorkers"]
         )
+        if type(maxWorkers) == int:
+            if maxWorkers > 0:
+                return maxWorkers
+            else:
+                return 1
+        else:
+            return cls.default["DownloadMaxWorkers"]
 
     # Indexing
     @classmethod

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -71,6 +71,7 @@ class Configuration:
         "backlog": 5,
         "Indexdir": "./indexdir",
         "updatelogfile": "./log/update_populate.log",
+        "DownloadMaxWorkers": 10,
         "Tmpdir": "./tmp",
         "http_proxy": "",
         "http_ignore_certs": False,
@@ -399,6 +400,13 @@ class Configuration:
     @classmethod
     def getBacklog(cls):
         return cls.readSetting("Logging", "Backlog", cls.default["backlog"])
+
+    # Download Max Workers
+    @classmethod
+    def getDownloadMaxWorkers(cls):
+        return cls.readSetting(
+            "Download", "MaxWorkers", cls.default["DownloadMaxWorkers"]
+        )
 
     # Indexing
     @classmethod

--- a/lib/DownloadHandler.py
+++ b/lib/DownloadHandler.py
@@ -118,7 +118,16 @@ class DownloadHandler(ABC):
 
         start_time = time.time()
 
-        thread_map(self.download_site, sites, desc="Downloading files")
+        self.logger.info(
+            f"Downloading files (max {self.config.getDownloadMaxWorkers()} workers)"
+        )
+
+        thread_map(
+            self.download_site,
+            sites,
+            desc="Downloading files",
+            max_workers=self.config.getDownloadMaxWorkers(),
+        )
 
         if self.do_process:
             thread_map(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==7.1.1
 pytest-cov==3.0.0
-codecov==2.1.12
+codecov==2.1.13
 beautifulsoup4==4.10.0
 sphinx==5.3.0
 sphinx-rtd-theme==1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==7.1.1
 pytest-cov==3.0.0
 codecov==2.1.13
-beautifulsoup4==4.10.0
+beautifulsoup4==4.11.0
 sphinx==5.3.0
 sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
The issue #890 was closed, but the bug was reproduced by three users (@nikalexo, @brainsht & @frosteyes).

This PR makes the `max_workers` for the download actions in the `lib/DownloadHandler.py` configurable.

The new section  `[Download]`  has a new configuration parameter `MaxWorkers` defaulting to `10` as suggested by @frosteyes.