### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-JWT-Extended==4.3.1
 Flask-Socketio==5.1.1
 Flask-WTF==1.0.1
 Flask-plugins==1.6.1
+flask-menu==0.7.2
 gevent==21.12.0
 gevent-websocket==0.10.1
 WTForms==3.0.1


### PR DESCRIPTION
Specified the flask-menu version. The latest release of the module (v1.0.0) currently breaks the cve-search webinterface