### PR TITLE
Pass mongodb connection string when initialize CveXplore

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -138,6 +138,13 @@ class Configuration:
 
     @classmethod
     def getMongoConnection(cls):
+        # jdt_NOTE: now correctly catches exceptions due to changes in pymongo 2.9 or later
+        # jdt_NOTE: https://api.mongodb.com/python/current/migrate-to-pymongo3.html#mongoclient-connects-asynchronously
+        connect = pymongo.MongoClient(cls.getMongoUri(), connect=False)
+        return connect[cls.getMongoDB()]
+
+    @classmethod
+    def getMongoUri(cls):
         mongoSrv = cls.readSetting("Database", "DnsSrvRecord", cls.default["mongoSrv"])
         mongoHost = cls.readSetting("Database", "Host", cls.default["mongoHost"])
         mongoPort = cls.readSetting("Database", "Port", cls.default["mongoPort"])
@@ -170,10 +177,8 @@ class Configuration:
             mongoURI = "mongodb://{host}:{port}/{db}".format(
                 host=mongoHost, port=mongoPort, db=mongoDB
             )
-        # jdt_NOTE: now correctly catches exceptions due to changes in pymongo 2.9 or later
-        # jdt_NOTE: https://api.mongodb.com/python/current/migrate-to-pymongo3.html#mongoclient-connects-asynchronously
-        connect = pymongo.MongoClient(mongoURI, connect=False)
-        return connect[mongoDB]
+
+        return mongoURI
 
     @classmethod
     def toPath(cls, path):

--- a/web/run.py
+++ b/web/run.py
@@ -27,16 +27,16 @@ auth_handler = FlaskAuthHandler()
 plugins = PluginManager()
 dbh = FlaskDatabaseHandler()
 
-cvex = CveXplore()
+config = Configuration()
+
+cvex = CveXplore(mongodb_connection_details={"host": config.getMongoUri()})
 
 app = None
 token_blacklist = None
 oidcClient = None
-config = None
 
 ACCESS_EXPIRES = timedelta(minutes=15)
 REFRESH_EXPIRES = timedelta(days=30)
-
 
 def create_app(version, run_path):
     global app, token_blacklist, oidcClient, config
@@ -45,8 +45,6 @@ def create_app(version, run_path):
 
     app.config["version"] = version
     app.config["run_path"] = run_path
-
-    config = Configuration()
 
     if config.getWebInterface().lower() == "full":
         app.config["WebInterface"] = False


### PR DESCRIPTION
Pass MongoDB connection string when initializing CveXplore. Since commit 8d4c6d45db48ea7ef9356a987be6bc2fdeab4e17 connection to MongoDB is set to default (127.0.0.1:27017, no auth)