### PR TITLE
Fixed Inappropriate Logical Expression

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -110,7 +110,7 @@ def cvesForCPE(
         target_version = cpe.split(":")[-1]
         product = cpe.rsplit(":", 1)[0]
         # perform checks on the target version
-        if None is target_version or [] is target_version:
+        if None is target_version or [] == target_version:
             print(
                 "Error, target version not found at the end of product description '{}'".format(
                     cpe


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [DatabaseLayer.py](https://github.com/cve-search/cve-search/blob/master/lib/DatabaseLayer.py#L113), method: cvesForCPE, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. iCR suggested that the logical operation should be reviewed for correctness.

#### Example
Running the following program gives us the output below
```python
foo = []
print([] is foo)
print([] == foo)
```
```
False
True
```


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
