### PR TITLE
Use count_documents() to count mongo documents instead of old and deprecated count()

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -318,7 +318,7 @@ def getCVEs(limit=False, query=[], skip=0, cves=None, collection=None):
                 .skip(skip)
             )
 
-    return {"results": sanitize(cve), "total": cve.count()}
+    return {"results": sanitize(cve), "total": cve.count_documents(filter={})}
 
 
 def getCVEsNewerThan(dt):
@@ -442,7 +442,7 @@ def getLastModified(collection):
 
 
 def getSize(collection):
-    return db[collection].count()
+    return db[collection].count_documents(filter={})
 
 
 def via4Linked(key, val):
@@ -458,8 +458,8 @@ def getDBStats(include_admin=False):
             "last_update": getLastModified(key.lower()),
         }
     if include_admin:
-        data["whitelist"] = {"size": colWHITELIST.count()}
-        data["blacklist"] = {"size": colBLACKLIST.count()}
+        data["whitelist"] = {"size": colWHITELIST.count_documents(filter={})}
+        data["blacklist"] = {"size": colBLACKLIST.count_documents(filter={})}
         data = {
             "stats": {
                 "size_on_disk": db.command("dbstats")["storageSize"],


### PR DESCRIPTION
Use count_documents() to count Mongo documents instead of old and deprecated count()

```
    **adminInfo(),
  File "/Users/quocbao/cve-search/web/home/utils.py", line 297, in adminInfo
    return {"stats": getDBStats(True), "updateOutput": filterUpdateField(output)}
  File "/Users/quocbao/cve-search/lib/DatabaseLayer.py", line 457, in getDBStats
    "size": getSize(key.lower()),
  File "/Users/quocbao/cve-search/lib/DatabaseLayer.py", line 445, in getSize
    return db[collection].count()
  File "/Users/quocbao/cve-search/venv/lib/python3.10/site-packages/pymongo/collection.py", line 3509, in __call__
    raise TypeError(
TypeError: 'Collection' object is not callable. If you meant to call the 'count' method on a 'Collection' object it is failing because no such method exists.
2023-12-11 14:40:33,404 - werkzeug - INFO     - 127.0.0.1 - - [11/Dec/2023 14:40:33] "GET /admin/ HTTP/1.1" 500 -
```

![CleanShot 2023-12-11 at 14 47 47](https://github.com/cve-search/cve-search/assets/1851037/1c91699f-a3bd-4d13-ba4e-69b2aa3e3610)


Since commit 8d4c6d45db48ea7ef9356a987be6bc2fdeab4e17 `pymongo` 4.5.0 have some breaking changes, for example they removed method. From version `4.0` they remove many methods including `count()`
https://pymongo.readthedocs.io/en/stable/changelog.html

```
Removed pymongo.collection.Collection.count().
```

