### PR TITLE
Fix counting results when searching for CVE using cli

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -318,7 +318,7 @@ def getCVEs(limit=False, query=[], skip=0, cves=None, collection=None):
                 .skip(skip)
             )
 
-    return {"results": sanitize(cve), "total": cve.count_documents(filter={})}
+    return {"results": sanitize(cve), "total": len(list(cve))}
 
 
 def getCVEsNewerThan(dt):


### PR DESCRIPTION
This PR correctly count results returned by `./bin/search.py -c <input cve>` 

Fix https://github.com/cve-search/cve-search/issues/1028

![CleanShot 2023-12-12 at 19 08 22](https://github.com/cve-search/cve-search/assets/1851037/d636e45f-76a5-487e-853a-2c3a40db19b5)
