### PR TITLE
Add workflow to check black formatting

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,20 @@
+name: Black formatting
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  black:
+    name: Black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Black formatting for Python scripts
+        uses: psf/black@stable
+        with:
+          options: --check --diff --verbose
+          src: .

--- a/lib/CVEs.py
+++ b/lib/CVEs.py
@@ -87,7 +87,6 @@ class CveHandler(object):
     # This method can be used to standardize a mongo doc
     # after getting it from mongo
     def getCveFromMongoDbDoc(self, cve_doc):
-
         if cve_doc is None:
             return None
 

--- a/web/helpers/flask_authentication.py
+++ b/web/helpers/flask_authentication.py
@@ -3,7 +3,6 @@ from lib.Authentication import AuthenticationHandler
 
 class FlaskAuthHandler(object):
     def __init__(self, app=None, **kwargs):
-
         self.kwargs = kwargs
 
         if app is not None:

--- a/web/helpers/flask_database.py
+++ b/web/helpers/flask_database.py
@@ -3,7 +3,6 @@ from lib.DatabaseHandler import DatabaseHandler
 
 class FlaskDatabaseHandler(object):
     def __init__(self, app=None, **kwargs):
-
         self.kwargs = kwargs
 
         if app is not None:


### PR DESCRIPTION
It seems this project drifts away from the black formatting and is occasionally reformatted using the Black linter manually. Could we automate it by adding this workflow that requires Black formatting to pass?

- [Add workflow to check black formatting](https://github.com/cve-search/cve-search/commit/1005fe239d0570e572ad160d5b0ea7944db37c11)
- [black formatting (23.12.1)](https://github.com/cve-search/cve-search/commit/d8550301371356cf0de015ab9651d0efa4d303b3) changes required by the new pipeline