### PR TITLE
systemd services: rename mongod.service

### DIFF
--- a/_etc/systemd/system/cvesearch.db_init.service
+++ b/_etc/systemd/system/cvesearch.db_init.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=circl dot lu CVE-Search database initialization (only run this once!)
-Requires=mongodb.service redis-server.service
-After=network.target mongodb.service redis-server.service
+Requires=mongod.service redis-server.service
+After=network.target mongod.service redis-server.service
 RefuseManualStart=true
 Documentation=https://cve-search.github.io/cve-search/getting_started/installation.html
 

--- a/_etc/systemd/system/cvesearch.db_repopulate.service
+++ b/_etc/systemd/system/cvesearch.db_repopulate.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=circl dot lu CVE-Search database repopulation (drop & reimport everything)
-Requires=mongodb.service redis-server.service
-After=network.target cvesearch.db_init.service cvesearch.db_updater.service mongodb.service redis-server.service
+Requires=mongod.service redis-server.service
+After=network.target cvesearch.db_init.service cvesearch.db_updater.service mongod.service redis-server.service
 RefuseManualStart=true
 Documentation=https://cve-search.github.io/cve-search/database/database.html
 

--- a/_etc/systemd/system/cvesearch.db_updater.service
+++ b/_etc/systemd/system/cvesearch.db_updater.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=circl dot lu CVE-Search db_updater service
-Requires=mongodb.service redis-server.service
-After=network.target cvesearch.db_init.service cvesearch.db_repopulate.service mongodb.service redis-server.service
+Requires=mongod.service redis-server.service
+After=network.target cvesearch.db_init.service cvesearch.db_repopulate.service mongod.service redis-server.service
 Documentation=https://cve-search.github.io/cve-search/database/database.html
 
 [Service]

--- a/_etc/systemd/system/cvesearch.web.service
+++ b/_etc/systemd/system/cvesearch.web.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=circl dot lu CVE-Search Web Server
-Requires=mongodb.service
-After=network.target cvesearch.db_init.service cvesearch.db_repopulate.service mongodb.service
+Requires=mongod.service
+After=network.target cvesearch.db_init.service cvesearch.db_repopulate.service mongod.service
 Documentation=https://cve-search.github.io/cve-search/webgui/webgui.html
 
 [Service]


### PR DESCRIPTION
At least for 3 years has the documentation used `mongodb-org` packages instead of MongoDB that was part of, e.g., Ubuntu Focal. The service name `mongodb.service` used in these examples comes from the `mongodb` package instead of `mongodb-org` that uses `mongod.service`. As that was before these examples, it is my bad.

These examples also require the fix from #1051 - I wish we get that one released as v5.0.1 soon.