### PR TITLE
Improve SystemD service examples

### DIFF
--- a/_etc/systemd/system/cvesearch.db_init.service
+++ b/_etc/systemd/system/cvesearch.db_init.service
@@ -6,10 +6,10 @@ RefuseManualStart=true
 Documentation=https://cve-search.github.io/cve-search/getting_started/installation.html
 
 [Service]
-WorkingDirectory=$(INSTALLDIR)
+WorkingDirectory=/opt/cve/cve-search
 ExecStart=python3 ./sbin/db_mgmt_cpe_dictionary.py -p
 ExecStart=python3 ./sbin/db_mgmt_json.py -p
 ExecStart=python3 ./sbin/db_updater.py -c
-User=$(CVE_USER)
+User=cve
 Type=oneshot
 SyslogIdentifier=cvesearch.db_updater

--- a/_etc/systemd/system/cvesearch.db_repopulate.service
+++ b/_etc/systemd/system/cvesearch.db_repopulate.service
@@ -6,8 +6,8 @@ RefuseManualStart=true
 Documentation=https://cve-search.github.io/cve-search/database/database.html
 
 [Service]
-WorkingDirectory=$(INSTALLDIR)
+WorkingDirectory=/opt/cve/cve-search
 ExecStart=python3 ./sbin/db_updater.py -v -f
-User=$(CVE_USER)
+User=cve
 Type=oneshot
 SyslogIdentifier=cvesearch.db_updater

--- a/_etc/systemd/system/cvesearch.db_updater.service
+++ b/_etc/systemd/system/cvesearch.db_updater.service
@@ -5,8 +5,8 @@ After=network.target cvesearch.db_init.service cvesearch.db_repopulate.service m
 Documentation=https://cve-search.github.io/cve-search/database/database.html
 
 [Service]
-WorkingDirectory=$(INSTALLDIR)
+WorkingDirectory=/opt/cve/cve-search
 ExecStart=python3 ./sbin/db_updater.py
-User=$(CVE_USER)
+User=cve
 Type=oneshot
 SyslogIdentifier=cvesearch.db_updater

--- a/_etc/systemd/system/cvesearch.db_updater.timer
+++ b/_etc/systemd/system/cvesearch.db_updater.timer
@@ -3,7 +3,10 @@ Description=circl dot lu CVE-Search db_updater trigger timer
 
 [Timer]
 Unit=cvesearch.db_updater.service
-OnCalendar=*-*-* 5:15:00
+OnActiveSec=0
+OnUnitActiveSec=7200
+OnUnitInactiveSec=7200
+RandomizedDelaySec=900
 
 [Install]
 WantedBy=timers.target

--- a/_etc/systemd/system/cvesearch.web.service
+++ b/_etc/systemd/system/cvesearch.web.service
@@ -5,9 +5,9 @@ After=network.target cvesearch.db_init.service cvesearch.db_repopulate.service m
 Documentation=https://cve-search.github.io/cve-search/webgui/webgui.html
 
 [Service]
-WorkingDirectory=$(INSTALLDIR)
+WorkingDirectory=/opt/cve/cve-search
 ExecStart=python3 ./web/index.py
-User=$(CVE_USER)
+User=cve
 Type=simple
 SyslogIdentifier=cvesearch.web
 Restart=always


### PR DESCRIPTION
- **SystemD: relative timer logic**. Relative timer logic suits the API based updates better. There seems to be CVE updates every hour. To distribute the load evenly, this updates the database every two hours, with additional 15 minute random delay.
- **SystemD: use installdir path & user from docs**. Docs for [Production Installation](https://cve-search.github.io/cve-search/getting_started/installation.html#production-installation) suggests certain paths & user. If other paths or user are used, they could still be updated accordingly, but the current "variables" doesn't exist and might be confusing.