### PR TITLE
GitHub workflow for automatic web/VERSION update

### DIFF
--- a/.github/workflows/auto_version.yaml
+++ b/.github/workflows/auto_version.yaml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/auto_version.yaml
+++ b/.github/workflows/auto_version.yaml
@@ -1,0 +1,35 @@
+name: Update web/VERSION
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+jobs:
+  update-web-version:
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Update version
+        run: |
+          python3 ./web/set_version.py
+      - name: Commit updated version
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add web/VERSION
+          git commit -m "Update web/VERSION $(cat web/VERSION)" -a || true
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: master
+          directory: .
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A pipeline that would automatically update the `web/VERSION` file was suggested in https://github.com/cve-search/cve-search/pull/877 but seems to be forgotten as there was never an issue opened.

This is an attempted solution to automatically push a commit whenever something is merged to `master`. However, this kind of pipeline is a bit hard to test without actually using it...