### PR TITLE
Cleanup: remove unused .talismanrc fileignore

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,4 +1,0 @@
-fileignoreconfig:
-- filename: lib/Config.py
-  checksum: 5af001a1c11abbd8d146f32e28764a9b6e151a975a5079da9502183d18a4cbfe
-version: ""


### PR DESCRIPTION
[Talisman](https://github.com/thoughtworks/talisman) is a tool that prevents developers from pushing secrets to public repositories. This file was added in https://github.com/cve-search/cve-search/pull/864; probably @eengelking was using it locally but forgot to gitignore its configuration file.

This file seems rather useless, because the checksum changes every time changes are committed to the file, and it has never been updated despite the file has changed. Furthermore, although the hashing utilizes SHA256 function, its results are different from running `sha256sum` over the contents of the file. I was a bit confused when none of the historical `sha256sum`s matched with the checksum on this file when I tried:

```
git log --oneline --no-abbrev-commit --follow -- lib/Config.py \
  | awk '{print $1}' \
  | while read commit; do \
      git show $commit:lib/Config.py \
        | sha256sum \
        | awk '{print $1}'; \
    done \
  | grep 5af001a1c11abbd8d146f32e28764a9b6e151a975a5079da9502183d18a4cbfe
```

A small pull request like this might help testing the pipeline from https://github.com/cve-search/cve-search/pull/1073 **after** the suggested changes from [issuecomment-2041309235](https://github.com/cve-search/cve-search/pull/1073#issuecomment-2041309235). 😉