### PR TITLE
SystemD db_updater.timer lower update interval

### DIFF
--- a/_etc/systemd/system/cvesearch.db_updater.timer
+++ b/_etc/systemd/system/cvesearch.db_updater.timer
@@ -4,9 +4,9 @@ Description=circl dot lu CVE-Search db_updater trigger timer
 [Timer]
 Unit=cvesearch.db_updater.service
 OnActiveSec=0
-OnUnitActiveSec=7200
-OnUnitInactiveSec=7200
-RandomizedDelaySec=900
+OnUnitActiveSec=3600
+OnUnitInactiveSec=3600
+RandomizedDelaySec=300
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
After the optimizations in https://github.com/cve-search/CveXplore/pull/272 (solving issue https://github.com/cve-search/CveXplore/issues/270), I dare to reduce the update interval to one hour with a clear conscience, which is also the update interval of the CVE source and the update interval used by `dp_updater.py -v -l` (loop mode).