### PR TITLE
Fix CPE name parsing

### DIFF
--- a/bin/search.py
+++ b/bin/search.py
@@ -26,6 +26,7 @@ sys.path.append(os.path.join(runPath, ".."))
 
 from lib.DatabaseLayer import cvesForCPE, getCVEs, getFreeText, getCVEIDs, searchCVE
 from lib.CVEs import CveHandler
+from CveXplore.common.cpe_converters import split_cpe_name
 
 
 # list comprehension helper functions
@@ -161,7 +162,7 @@ def print_job(item):
 
 def search_product(prod):
     if strict_vendor_product:
-        search = prod.split(":")
+        search = split_cpe_name(prod)
         search = (search[0], search[1])
         ret = cvesForCPE(
             search,
@@ -214,7 +215,7 @@ if pyReq:
             # check if any of those is allowed according to specs
             found = False
             for vuln in vulns.keys():
-                sp = vuln.split(":")
+                sp = split_cpe_name(vuln)
                 ind = -1
                 num = sp[ind]
                 # if the last token is not a number or float then it must be e.g., 'alpha' while the

--- a/bin/search.py
+++ b/bin/search.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(runPath, ".."))
 
 from lib.DatabaseLayer import cvesForCPE, getCVEs, getFreeText, getCVEIDs, searchCVE
 from lib.CVEs import CveHandler
-from CveXplore.common.cpe_converters import split_cpe_name
+from lib.cpe_conversion import split_cpe_name
 
 
 # list comprehension helper functions

--- a/lib/CVEs.py
+++ b/lib/CVEs.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 from lib.DatabaseLayer import getCVE, sanitize
+from lib.cpe_conversion import split_cpe_name
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
@@ -133,7 +134,7 @@ class CveHandler(object):
         i = None
 
         if loosy:
-            for x in cpeid.split(":"):
+            for x in split_cpe_name(cpeid):
                 if x != "":
                     i = findRanking(x, regex=True)
                 if i is None:

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -14,6 +14,7 @@ import sys
 import pymongo
 
 from lib.Config import Configuration as conf
+from lib.cpe_conversion import split_cpe_name
 
 # Variables
 db = conf.getMongoConnection()
@@ -107,8 +108,9 @@ def cvesForCPE(
 
     if lax:
         # get target version from product description provided by the user
-        target_version = cpe.split(":")[-1]
-        product = cpe.rsplit(":", 1)[0]
+        cpe_name = split_cpe_name(cpe)
+        target_version = cpe_name[-1]
+        product = ":".join(cpe_name[:-1])
         # perform checks on the target version
         if None is target_version or [] == target_version:
             print(
@@ -176,7 +178,8 @@ def cvesForCPE(
                 cpe_version = re_from_start.sub("", vc)
 
                 # TODO: handle versions such as "1.1.3:p2"
-                cpe_version = cpe_version.split(":")[0]
+                # Should work now, I don't know the context of this code.
+                cpe_version = split_cpe_name(cpe_version)[0]
 
                 # TODO: handle versions such as "1.1.3p2"
                 cpe_version = re.search(r"([0-9\.]*)", cpe_version).group(0)

--- a/lib/Query.py
+++ b/lib/Query.py
@@ -14,6 +14,8 @@ import urllib.parse
 
 import requests
 
+from lib.cpe_conversion import split_cpe_name
+
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 
@@ -38,7 +40,7 @@ def findranking(cpe=None, loosy=True):
     result = False
 
     if loosy:
-        for x in cpe.split(":"):
+        for x in split_cpe_name(cpe):
             if x != "":
                 i = findRanking(cpe, regex=True)
             if i is None:

--- a/lib/Sources_process.py
+++ b/lib/Sources_process.py
@@ -9,6 +9,7 @@ from lib.Config import Configuration
 from lib.DatabaseLayer import (
     getCPEs,
 )
+from lib.cpe_conversion import split_cpe_name
 
 
 class CPERedisBrowser(object):
@@ -33,9 +34,9 @@ class CPERedisBrowser(object):
         start_time = time.time()
         for e in tqdm(self.cpes, desc="Inserting CPE's in redis"):
             value = e["cpeName"]
-            (prefix, cpeversion, cpetype, vendor, product, version) = value.split(
-                ":", 5
-            )
+            cpe_name = split_cpe_name(value)
+            (prefix, cpeversion, cpetype, vendor, product) = cpe_name[:5]
+            version = ":".join(cpe_name[5:])
 
             if self.set_debug_logging:
                 self.logger.debug("prefix: {}".format(prefix))

--- a/lib/Toolkit.py
+++ b/lib/Toolkit.py
@@ -21,7 +21,7 @@ def toStringFormattedCPE(cpe, autofill=False):
             return False
         cpe = lib.cpe_conversion.cpe_uri_to_fs(cpe)
     if autofill:
-        e = cpe.split(":")
+        e = lib.cpe_conversion.split_cpe_name(cpe)
         for x in range(0, 13 - len(e)):
             cpe += ":-"
     return cpe

--- a/lib/cpe_conversion.py
+++ b/lib/cpe_conversion.py
@@ -10,6 +10,14 @@
 
 import re
 
+def split_cpe_name(cpename: str) -> list[str]:
+    """
+    Split CPE 2.3 into its components, accounting for escaped colons.
+    """
+    non_escaped_colon = r"(?<!\\):"
+    split_name = re.split(non_escaped_colon, cpename)
+    return split_name
+
 
 # Convert cpe2.2 url encoded to cpe2.3 char escaped
 # cpe:2.3:o:cisco:ios:12.2%281%29 to cpe:2.3:o:cisco:ios:12.2\(1\)

--- a/lib/cpe_conversion.py
+++ b/lib/cpe_conversion.py
@@ -10,6 +10,7 @@
 
 import re
 
+
 def split_cpe_name(cpename: str) -> list[str]:
     """
     Split CPE 2.3 into its components, accounting for escaped colons.

--- a/sbin/db_ranking.py
+++ b/sbin/db_ranking.py
@@ -26,6 +26,8 @@ import argparse
 import os
 import sys
 
+from lib.cpe_conversion import split_cpe_name
+
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 
@@ -46,7 +48,7 @@ def findranking(cpe=None, loosy=True):
     i = None
 
     if loosy:
-        for x in cpe.split(":"):
+        for x in split_cpe_name(cpe):
             if x != "":
                 i = findRanking(x, regex=True)
             if i is None:


### PR DESCRIPTION
Fix #1079
I grepped for relevant uses of split(":"), and switched them to a split_cpe_name function. The function is currently duplicated, but could be switched over to the CveXplore one if a
new version was published.