### PR TITLE
Support non-numeric versions in relaxSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,13 +216,13 @@ A public version of the API is also accessible on [cve.circl.lu](https://cve.cir
 List the know vendors in JSON
 
 ```bash
-curl http://127.0.0.1:5000/api/browse/
+curl "http://127.0.0.1:5000/api/browse/"
 ```
 
 Dump the product of a specific vendor in JSON
 
 ```jq
-curl  http://127.0.0.1:5000/api/browse/zyxel
+curl "http://127.0.0.1:5000/api/browse/zyxel"
 {
   "product": [
     "n300_netusb_nbg-419n",
@@ -246,7 +246,7 @@ curl  http://127.0.0.1:5000/api/browse/zyxel
 Find the associated vulnerabilities to a vendor and a product.
 
 ```jq
-curl  http://127.0.0.1:5000/api/search/zyxel/p-660hw | jq .
+curl "http://127.0.0.1:5000/api/search/zyxel/p-660hw" | jq .
 [
   {
     "cwe": "CWE-352",
@@ -287,7 +287,6 @@ curl  http://127.0.0.1:5000/api/search/zyxel/p-660hw | jq .
       "cpe:/h:zyxel:p-660hw:_t1:v2",
       "cpe:/h:zyxel:p-660hw:_t1:-"
     ],
-. . .
 ````
 
 ## Software using cve-search

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Check the [documentation](https://cve-search.github.io/cve-search/) to get you s
 Usage
 -----
 
+You can search the database using search.py.
+
 ``` 
 usage: search.py [-h] [-q Q] [-p P [P ...]] [--only-if-vulnerable] [--strict_vendor_product] [--lax] [-f F] [-c C] [-o O]
                  [-l] [-n] [-r] [-a] [-v V] [-s S] [-t T] [-i I]
@@ -67,23 +69,22 @@ options:
   -i I                  Limit output to n elements (default: unlimited)
 ```
 
-You can search the database using search.py
+Examples:
 
     ./bin/search.py -p cisco:ios:12.4
     ./bin/search.py -p cisco:ios:12.4 -o json
     ./bin/search.py -f nagios -n
     ./bin/search.py -p microsoft:windows_7 -o html
 
-If you want to search all the WebEx vulnerabilities and only printing the official
-references from the supplier.
+If you want to search all the WebEx vulnerabilities and only printing the official references from the supplier.
 
     ./bin/search.py -p webex: -o csv  -v "cisco"
 
 You can also dump the JSON for a specific CVE ID.
 
-    ./bin/search.py -c CVE-2010-3333
+    ./bin/search.py -c CVE-2010-3333 -o json
 
-Or dump the last 2 CVE entries in RSS or Atom format
+Or dump the last 2 CVE entries in RSS or Atom format.
 
     ./bin/dump_last.py -f atom -l 2
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ options:
   -p P [P ...]          S = search one or more products, e.g. o:microsoft:windows_7 or o:cisco:ios:12.1 or
                         o:microsoft:windows_7 o:cisco:ios:12.1. Add --only-if-vulnerable if only vulnerabilities that
                         directly affect the product are wanted.
-  --only-if-vulnerable  With this option, "-p" will only return vulnerabilities directly assigned to the product. I.e. it
-                        will not consider "windows_7" if it is only mentioned as affected OS in an adobe:reader
+  --only-if-vulnerable  With this option, "-p" will only return vulnerabilities directly assigned to the product. I.e.
+                        it will not consider "windows_7" if it is only mentioned as affected OS in an adobe:reader
                         vulnerability.
   --strict_vendor_product
-                        With this option, a strict vendor product search is executed. The values in "-p" should be formatted
-                        as vendor:product, e.g. microsoft:windows_7
-  --lax                 Strict search for software version is disabled. Note that this option only support product
-                        description with numerical values only (of the form cisco:ios:1.2.3)
+                        With this option, a strict vendor product search is executed. The values in "-p" should be
+                        formatted as vendor:product, e.g. microsoft:windows_7
+  --lax                 Strict search for software version is disabled. Likely gives false positives for earlier
+                        versions that were not yet vulnerable. Note that version comparison for non-numeric values
+                        is done with simplifications.
   -f F                  F = free text search in vulnerability summary
   -c C                  search one or more CVE-ID
   -o O                  O = output format [csv|html|json|xml|cveid]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-cve-search
-==========
+# cve-search
 
 [![Join the chat at https://gitter.im/cve-search/cve-search](https://badges.gitter.im/cve-search/cve-search.svg)](https://gitter.im/cve-search/cve-search?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 ![Build & Test](https://github.com/cve-search/cve-search/workflows/Build%20&%20Test/badge.svg)
@@ -26,16 +25,15 @@ This document gives you basic information how to start with cve-search. For more
 information please refer to the documentation in the **_/doc_** folder of this
 project.
 
-Getting started
----------------
+## Getting started
+
 Check the [documentation](https://cve-search.github.io/cve-search/) to get you started
 
-Usage
------
+## Usage
 
 You can search the database using search.py.
 
-``` 
+```text
 usage: search.py [-h] [-q Q] [-p P [P ...]] [--only-if-vulnerable] [--strict_vendor_product] [--lax] [-f F] [-c C] [-o O]
                  [-l] [-n] [-r] [-a] [-v V] [-s S] [-t T] [-i I]
 
@@ -71,29 +69,38 @@ options:
 
 Examples:
 
-    ./bin/search.py -p cisco:ios:12.4
-    ./bin/search.py -p cisco:ios:12.4 -o json
-    ./bin/search.py -f nagios -n
-    ./bin/search.py -p microsoft:windows_7 -o html
+```bash
+./bin/search.py -p cisco:ios:12.4
+./bin/search.py -p cisco:ios:12.4 -o json
+./bin/search.py -f nagios -n
+./bin/search.py -p microsoft:windows_7 -o html
+```
 
 If you want to search all the WebEx vulnerabilities and only printing the official references from the supplier.
 
-    ./bin/search.py -p webex: -o csv  -v "cisco"
+```bash
+./bin/search.py -p webex: -o csv  -v "cisco"
+```
 
 You can also dump the JSON for a specific CVE ID.
 
-    ./bin/search.py -c CVE-2010-3333 -o json
+```bash
+./bin/search.py -c CVE-2010-3333 -o json
+```
 
 Or dump the last 2 CVE entries in RSS or Atom format.
 
-    ./bin/dump_last.py -f atom -l 2
+```bash
+./bin/dump_last.py -f atom -l 2
+```
 
 Or you can use the webinterface.
 
-    ./web/index.py
+```bash
+./web/index.py
+```
 
-Usage of the ranking database
------------------------------
+## Usage of the ranking database
 
 There is a ranking database allowing to rank software vulnerabilities based on
 their common platform enumeration name. The ranking can be done per organization
@@ -102,58 +109,76 @@ or department within your organization or any meaningful name for you.
 As an example, you can add a partial CPE name like "sap:netweaver" which is very
 critical for your accounting department.
 
-    ./sbin/db_ranking.py  -c "sap:netweaver" -g "accounting" -r 3
+```bash
+./sbin/db_ranking.py  -c "sap:netweaver" -g "accounting" -r 3
+```
 
 and then you can lookup the ranking (-r option) for a specific CVE-ID:
 
-    ./bin/search.py -c CVE-2012-4341  -r  -n
+```bash
+./bin/search.py -c CVE-2012-4341  -r  -n
+```
 
-Advanced usage
---------------
+## Advanced usage
 
 As cve-search is based on a set of tools, it can be used and combined with standard Unix tools. If you ever wonder what are the top vendors using the term "unknown" for their vulnerabilities:
 
-    python3 bin/search_fulltext.py -q unknown -f | jq -c '. | .vulnerable_configuration[0]' | cut -f5 -d: | sort  | uniq -c  | sort -nr | head -10
+```bash
+python3 bin/search_fulltext.py -q unknown -f \
+    | jq -c '. | .vulnerable_configuration[0]' \
+    | cut -f5 -d: | sort  | uniq -c  | sort -nr | head -10
 
-    1500 oracle
-    381 sun
-    372 hp
-    232 google
-    208 ibm
-    126 mozilla
-    103 microsoft
-    100 adobe
-     78 apple
-     68 linux
+1500 oracle
+381 sun
+372 hp
+232 google
+208 ibm
+126 mozilla
+103 microsoft
+100 adobe
+ 78 apple
+ 68 linux
+ ```
 
 You can compare CVSS (Common Vulnerability Scoring System ) values of some products based on their CPE name. Like comparing oracle:java versus sun:jre and using R to make some statistics about their CVSS values:
 
-    python3 bin/search.py -p oracle:java -o json  | jq -r '.cvss' | Rscript -e 'summary(as.numeric(read.table(file("stdin"))[,1]))'
-    Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
-    1.800   5.350   9.300   7.832  10.000  10.000
+```bash
+python3 bin/search.py -p oracle:java -o json \
+  | jq -r '.cvss' | Rscript -e 'summary(as.numeric(read.table(file("stdin"))[,1]))'
 
+Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
+1.800   5.350   9.300   7.832  10.000  10.000
+```
 
-    python3 bin/search.py -p sun:jre -o json  | jq -r '.cvss' | Rscript -e 'summary(as.numeric(read.table(file("stdin"))[,1]))'
-    Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
-    0.000   5.000   7.500   7.333  10.000  10.000
+```bash
+python3 bin/search.py -p sun:jre -o json \
+  | jq -r '.cvss' | Rscript -e 'summary(as.numeric(read.table(file("stdin"))[,1]))'
 
-Fulltext indexing
------------------
+Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
+0.000   5.000   7.500   7.333  10.000  10.000
+```
+
+## Fulltext indexing
 
 If you want to index all the CVEs from your current MongoDB collection:
 
-    ./sbin/db_fulltext.py -l 0
+```bash
+./sbin/db_fulltext.py -l 0
+```
 
 and you query the fulltext index (to get a list of matching CVE-ID):
 
-    ./bin/search_fulltext.py -q NFS -q Linux
+```bash
+./bin/search_fulltext.py -q NFS -q Linux
+```
 
 or to query the fulltext index and output the JSON object for each CVE-ID:
 
-    ./bin/search_fulltext.py -q NFS -q Linux -f
+```bash
+./bin/search_fulltext.py -q NFS -q Linux -f
+```
 
-Fulltext visualization
-----------------------
+## Fulltext visualization
 
 The fulltext indexer visualization is using the fulltext indexes to build
 a list of the most common keywords used in CVE. [NLTK](http://nltk.org/) is
@@ -161,39 +186,42 @@ required to generate the keywords with the most common English
 stopwords and lemmatize the output. [NTLK for Python 3](http://nltk.org/nltk3-alpha/)
 exists but you need to use the alpha version of NLTK.
 
-    ./bin/search_fulltext.py  -g -s >cve.json
+```bash
+./bin/search_fulltext.py  -g -s >cve.json
+```
 
 ![cve-search visualization](https://farm9.staticflickr.com/8109/8603509755_c7690c2de4_n.jpg "CVE Keywords Visualization Using Data From cve-search")
 
 You can see a visualization on the [demo site](http://www.foo.be/cve/).
 
-Web interface
--------------
+## Web interface
 
 The web interface is a minimal interface to see the last CVE entries and
-query a specific CVE. You'll need flask in order to run the website and [Flask-PyMongo](http://flask-pymongo.readthedocs.org/en/latest/). To start
+query a specific CVE. You'll need flask in order to run the website and
+[Flask-PyMongo](http://flask-pymongo.readthedocs.org/en/latest/). To start
 the web interface:
 
-    cd ./web
-    ./index.py
+```bash
+cd ./web
+./index.py
+```
 
-Then you can connect on http://127.0.0.1:5000/ to browser the last CVE.
+Then you can connect on `http://127.0.0.1:5000/` to browser the last CVE.
 
-Web API interface
------------------
+## Web API interface
 
 The web interface includes a minimal JSON API to get CVE by ID, by vendor or product.
 A public version of the API is also accessible on [cve.circl.lu](https://cve.circl.lu/).
 
 List the know vendors in JSON
 
-~~~
+```bash
 curl http://127.0.0.1:5000/api/browse/
-~~~
+```
 
 Dump the product of a specific vendor in JSON
 
-~~~
+```jq
 curl  http://127.0.0.1:5000/api/browse/zyxel
 {
   "product": [
@@ -213,17 +241,56 @@ curl  http://127.0.0.1:5000/api/browse/zyxel
   ],
   "vendor": "zyxel"
 }
-~~~
+```
 
-Find the associated vulnerabilities to a vendor and a product
+Find the associated vulnerabilities to a vendor and a product.
 
-~~~
-curl  http://127.0.0.1:5000/api/search/zyxel/p-660hw
-[{"cwe": "CWE-352", "references": ["http://www.exploit-db.com/exploits/33518", "http://secunia.com/advisories/58513", "http://packetstormsecurity.com/files/126812/Zyxel-P-660HW-T1-Cross-Site-Request-Forgery.html", "http://osvdb.org/show/osvdb/107449"], "vulnerable_configuration": ["cpe:/h:zyxel:p-660hw:_t1:v3"], "Published": "2014-06-16T14:55:09.713-04:00", "id": "CVE-2014-4162", "Modified": "2014-07-17T01:07:29.683-04:00", "cvss": 6.8, "summary": "Multiple cross-site request forgery (CSRF) vulnerabilities in the Zyxel P-660HW-T1 (v3) wireless router allow remote attackers to hijack the authentication of administrators for requests that change the (1) wifi password or (2) SSID via a request to Forms/WLAN_General_1."}, {"cwe": "CWE-20", "references": ["http://www.kb.cert.org/vuls/id/893726"], "vulnerable_configuration": ["cpe:/h:zyxel:p-660h-63:-", "cpe:/h:zyxel:p-660h-t1:-", "cpe:/h:zyxel:p-660h-d3:-", "cpe:/h:zyxel:p-660h-t3:v2", "cpe:/h:zyxel:p-660h-t1:v2", "cpe:/h:zyxel:p-660h-d1:-", "cpe:/h:zyxel:p-660h-67:-", "cpe:/h:zyxel:p-660h-61:-", "cpe:/h:zyxel:p-660hw_t3:v2", "cpe:/h:zyxel:p-660hw_t3:-", "cpe:/h:zyxel:p-660hw_d3:-", "cpe:/h:zyxel:p-660hw_d1:v2", "cpe:/h:zyxel:p-660hw_d1:-", "cpe:/h:zyxel:p-660hw:_t1:v2", "cpe:/h:zyxel:p-660hw:_t1:-"], "Published": "2014-04-01T23:58:16.967-04:00", "id": "CVE-2013-3588", "Modified": "2014-04-02T11:29:53.243-04:00", "cvss": 7.8, "summary": "The web management interface on Zyxel P660 devices allows remote attackers to cause a denial of service (reboot) via a flood of TCP SYN packets."}, {"cwe": "CWE-79", "references": ["http://osvdb.org/ref/99/rompager407.pdf", "http://osvdb.org/99694", "http://antoniovazquezblanco.github.io/docs/advisories/Advisory_RomPagerXSS.pdf"], "vulnerable_configuration": ["cpe:/h:d-link:dsl-2640r:-", "cpe:/h:d-link:dsl-2641r:-", "cpe:/h:huawei:mt882:-", "cpe:/h:sitecom:wl-174:-", "cpe:/h:tp-link:td-8816:-", "cpe:/a:allegrosoft:rompager:4.07", "cpe:/h:zyxel:p-660hw_d1:-"], "Published": "2014-01-16T14:55:04.607-05:00", "id": "CVE-2013-6786", "Modified": "2014-01-17T11:01:47.353-05:00", "cvss": 4.3, "summary": "Cross-site scripting (XSS) vulnerability in Allegro RomPager before 4.51, as used on the ZyXEL P660HW-D1, Huawei MT882, Sitecom WL-174, TP-LINK TD-8816, and D-Link DSL-2640R and DSL-2641R, when the \"forbidden author header\" protection mechanism is bypassed, allows remote attackers to inject arbitrary web script or HTML by requesting a nonexistent URI in conjunction with a crafted HTTP Referer header that is not properly handled in a 404 page.  NOTE: there is no CVE for a \"URL redirection\" issue that some sources list separately."}, {"cwe": "CWE-79", "references": ["http://xforce.iss.net/xforce/xfdb/41109", "http://www.securityfocus.com/archive/1/archive/1/489009/100/0/threaded", "http://www.gnucitizen.org/projects/router-hacking-challenge/"], "vulnerable_configuration": ["cpe:/h:zyxel:p-660hw_t3:v2", "cpe:/h:zyxel:p-660hw:_t1:v2", "cpe:/h:zyxel:p-660hw_d1:v2", "cpe:/h:zyxel:p-660hw_t3:-", "cpe:/h:zyxel:p-660hw:_t1:-", "cpe:/h:zyxel:p-660hw_d3:-", "cpe:/h:zyxel:p-660hw_d1:-"], "Published": "2008-03-10T13:44:00.000-04:00", "id": "CVE-2008-1257", "Modified": "2012-05-31T00:00:00.000-04:00", "cvss": 4.3, "summary": "Cross-site scripting (XSS) vulnerability in Forms/DiagGeneral_2 on the ZyXEL P-660HW series router allows remote attackers to inject arbitrary web script or HTML via the PingIPAddr parameter."}, {"id": "CVE-2008-1256", "references": ["http://xforce.iss.net/xforce/xfdb/41108", "http://www.securityfocus.com/archive/1/archive/1/489009/100/0/threaded", "http://www.gnucitizen.org/projects/router-hacking-challenge/"], "vulnerable_configuration": ["cpe:/h:zyxel:p-660hw"], "Published": "2008-03-10T13:44:00.000-04:00", "Modified": "2011-03-07T22:06:25.080-05:00", "cvss": 10.0, "summary": "The ZyXEL P-660HW series router has \"admin\" as its default password, which allows remote attackers to gain administrative access."}, {"cwe": "CWE-264", "references": ["http://www.securityfocus.com/archive/1/archive/1/489009/100/0/threaded", "http://www.gnucitizen.org/projects/router-hacking-challenge/", "http://xforce.iss.net/xforce/xfdb/41114"], "vulnerable_configuration": ["cpe:/h:zyxel:p-660hw"], "Published": "2008-03-10T13:44:00.000-04:00", "id": "CVE-2008-1255", "Modified": "2008-09-05T17:37:15.440-04:00", "cvss": 10.0, "summary": "The ZyXEL P-660HW series router maintains authentication state by IP address, which allows remote attackers to bypass authentication by establishing a session from a source IP address of a previously authenticated user."}, {"cwe": "CWE-352", "references": ["http://www.securityfocus.com/archive/1/archive/1/489009/100/0/threaded", "http://www.gnucitizen.org/projects/router-hacking-challenge/", "http://xforce.iss.net/xforce/xfdb/41111"], "vulnerable_configuration": ["cpe:/h:zyxel:p-660hw"], "Published": "2008-03-10T13:44:00.000-04:00", "id": "CVE-2008-1254", "Modified": "2008-09-05T17:37:15.287-04:00", "cvss": 6.8, "summary": "Multiple cross-site request forgery (CSRF) vulnerabilities on the ZyXEL P-660HW series router allow remote attackers to (1) change DNS servers and (2) add keywords to the \"bannedlist\" via unspecified vectors."}]
-~~~
+```jq
+curl  http://127.0.0.1:5000/api/search/zyxel/p-660hw | jq .
+[
+  {
+    "cwe": "CWE-352",
+    "references": [
+      "http://www.exploit-db.com/exploits/33518",
+      "http://secunia.com/advisories/58513",
+      "http://packetstormsecurity.com/files/126812/Zyxel-P-660HW-T1-Cross-Site-Request-Forgery.html",
+      "http://osvdb.org/show/osvdb/107449"
+    ],
+    "vulnerable_configuration": [
+      "cpe:/h:zyxel:p-660hw:_t1:v3"
+    ],
+    "Published": "2014-06-16T14:55:09.713-04:00",
+    "id": "CVE-2014-4162",
+    "Modified": "2014-07-17T01:07:29.683-04:00",
+    "cvss": 6.8,
+    "summary": "Multiple cross-site request forgery (CSRF) vulnerabilities in the Zyxel P-660HW-T1 (v3) wireless router allow remote attackers to hijack the authentication of administrators for requests that change the (1) wifi password or (2) SSID via a request to Forms/WLAN_General_1."
+  },
+  {
+    "cwe": "CWE-20",
+    "references": [
+      "http://www.kb.cert.org/vuls/id/893726"
+    ],
+    "vulnerable_configuration": [
+      "cpe:/h:zyxel:p-660h-63:-",
+      "cpe:/h:zyxel:p-660h-t1:-",
+      "cpe:/h:zyxel:p-660h-d3:-",
+      "cpe:/h:zyxel:p-660h-t3:v2",
+      "cpe:/h:zyxel:p-660h-t1:v2",
+      "cpe:/h:zyxel:p-660h-d1:-",
+      "cpe:/h:zyxel:p-660h-67:-",
+      "cpe:/h:zyxel:p-660h-61:-",
+      "cpe:/h:zyxel:p-660hw_t3:v2",
+      "cpe:/h:zyxel:p-660hw_t3:-",
+      "cpe:/h:zyxel:p-660hw_d3:-",
+      "cpe:/h:zyxel:p-660hw_d1:v2",
+      "cpe:/h:zyxel:p-660hw_d1:-",
+      "cpe:/h:zyxel:p-660hw:_t1:v2",
+      "cpe:/h:zyxel:p-660hw:_t1:-"
+    ],
+. . .
+````
 
-Software using cve-search
--------------------------
+## Software using cve-search
 
 * [MISP modules](http://misp.github.io/misp-modules/expansion/#cve) cve-search to interact with MISP
 * [MISP module cve-advanced](https://github.com/MISP/misp-modules/blob/master/misp_modules/modules/expansion/cve_advanced.py) to import complete CVE as MISP objects
@@ -232,29 +299,29 @@ Software using cve-search
 * [cve-scan](https://www.github.com/NorthernSec/cve-scan) which is a NMap CVE system scanner
 * [Mercator](https://www.github.com/dbarzin/mercator) which is an application that allow the mapping of an information system
 
+## Docker versions
 
-Docker versions
----------------
 Official dockerized version of cve-search:
 
 [CVE-Search-Docker](https://github.com/cve-search/CVE-Search-Docker)
 
 There are some unofficial dockerized versions of cve-search (which are not maintained by us):
 
-- [docker-cve-search](https://github.com/ttimasdf/docker-cve-search)
-- [cve-search-docker](https://github.com/leojcollard/cve-search-docker)
+* [docker-cve-search](https://github.com/ttimasdf/docker-cve-search)
+* [cve-search-docker](https://github.com/leojcollard/cve-search-docker)
 
-Changelog
----------
+## Changelog
 
-You can find the changelog on [GitHub Releases](https://github.com/cve-search/cve-search/releases) ([legacy changelog](https://www.cve-search.org/Changelog.txt)).
+You can find the changelog on [GitHub Releases](https://github.com/cve-search/cve-search/releases)
+([legacy changelog](https://www.cve-search.org/Changelog.txt)).
 
-License
--------
+## License
 
 cve-search is free software released under the "GNU Affero General Public License v3.0"
 
-    Copyright (c) 2012 Wim Remes - https://github.com/wimremes/
-    Copyright (c) 2012-2024 Alexandre Dulaunoy - https://github.com/adulau/
-    Copyright (c) 2015-2019 Pieter-Jan Moreels - https://github.com/pidgeyl/
-    Copyright (c) 2020-2024 Paul Tikken - https://github.com/P-T-I
+```text
+Copyright (c) 2012 Wim Remes - https://github.com/wimremes/
+Copyright (c) 2012-2024 Alexandre Dulaunoy - https://github.com/adulau/
+Copyright (c) 2015-2019 Pieter-Jan Moreels - https://github.com/pidgeyl/
+Copyright (c) 2020-2024 Paul Tikken - https://github.com/P-T-I
+```

--- a/bin/search.py
+++ b/bin/search.py
@@ -86,8 +86,8 @@ argParser.add_argument(
     "--lax",
     default=False,
     action="store_true",
-    help="Strict search for software version is disabled. Note that this option only support product description with "
-    "numerical values only (of the form cisco:ios:1.2.3) ",
+    help="Strict search for software version is disabled. Likely gives false positives for earlier versions that "
+    "were not yet vulnerable. Note that version comparison for non-numeric values is done with simplifications.",
 )
 argParser.add_argument(
     "-f", type=str, help="F = free text search in vulnerability summary"
@@ -172,6 +172,10 @@ def search_product(prod):
         )
     else:
         ret = cvesForCPE(prod, lax=relaxSearch, vulnProdSearch=vulnerableProductSearch)
+    if "notices" in ret:
+        for notice in ret["notices"]:
+            print(f"{notice}")
+        print()  # Empty line to separate the notices from the results.
     for item in ret["results"]:
         if not last_ndays:
             print_job(item)

--- a/bin/search.py
+++ b/bin/search.py
@@ -29,13 +29,6 @@ from lib.CVEs import CveHandler
 from lib.cpe_conversion import split_cpe_name
 
 
-# list comprehension helper functions
-def replace_special_chars(cpe):
-    cpe = re.sub(r"\(", "%28", cpe)
-    cpe = re.sub(r"\)", "%29", cpe)
-    return cpe
-
-
 # init control variables
 csvOutput = 0
 htmlOutput = 0
@@ -253,11 +246,6 @@ if pyReq:
                                 found = True
     sys.exit(0)
 
-
-# replace special characters in vSearch with encoded version.
-# Basically cuz I'm to lazy to handle conversion on DB creation ...
-if vSearch:
-    vSearch = [replace_special_chars(cpe) for cpe in vSearch]
 
 # define which output to generate.
 if vOutput == "csv":

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -184,7 +184,7 @@ def cvesForCPE(
                 cpe_version = split_cpe_name(cpe_version)[0]
 
                 # Simplify equally with the target_version to enable comparison
-                cpe_version_simplified = re.sub(r"[^\d\.]", ".0.", cpe_version)
+                cpe_version_simplified = re.sub(r"[^\d\.]+", ".0.", cpe_version)
                 cpe_version_simplified = re.sub(r"[\.]+", ".", cpe_version_simplified)
                 cpe_version_simplified = cpe_version_simplified.strip(".")
 

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -100,35 +100,40 @@ def cvesForCPE(
     if not cpe:
         return []
 
+    notices = []
+
     cpe_regex = cpe
     final_cves = []
     cpe_searchField = (
         "vulnerable_product" if vulnProdSearch else "vulnerable_configuration"
     )
 
+    # relaxSearch for search.py --lax; Strict search for software version is disabled.
     if lax:
         # get target version from product description provided by the user
         cpe_name = split_cpe_name(cpe)
+        if len(cpe_name) != 3:
+            raise ValueError(
+                f"Format 'vendor:product:version' expected in --lax mode, got '{cpe}'"
+            )
         target_version = cpe_name[-1]
         product = ":".join(cpe_name[:-1])
-        # perform checks on the target version
-        if None is target_version or [] == target_version:
-            print(
-                "Error, target version not found at the end of product description '{}'".format(
-                    cpe
-                )
+
+        # For easier version comparison of exceptional version strings (not simple 1.2.3), simplify
+        # version strings containing non-numeric characters like "1.1.3p2" or "1.1.3mr2" as "1.1.3.0.2";
+        # the extra zero (.0.) is for avoiding collisions between, e.g., "1.0p1" and "1.0.1",
+        # where 1.0p1, converted to 1.0.0.1, will be less than 1.0.1.
+        target_version_simplified = re.sub(r"[^\d\.]+", ".0.", target_version)
+        # ...and then remove duplicate, leading & tailing dots
+        target_version_simplified = re.sub(r"[\.]+", ".", target_version_simplified)
+        target_version_simplified = target_version_simplified.strip(".")
+
+        # Notify user of the simplification.
+        if target_version_simplified != target_version:
+            notices.append(
+                f"Notice: Target version {target_version} simplified as {target_version_simplified} for "
+                f"easier version comparison; doing the same for CPEs in Vulnerable Configs under the hood."
             )
-            sys.exit(-1)
-        for i in target_version.split("."):
-            try:
-                int(i)
-            except:
-                print(
-                    "Error, target version should be of the form '1.2.3'. Current form is '{}'".format(
-                        target_version
-                    )
-                )
-                sys.exit(-1)
 
         # over-approximate versions
         cpe_regex = product
@@ -176,20 +181,21 @@ def cvesForCPE(
 
                 re_from_start = re.compile("^.*{}:".format(re.escape(cpe_regex)))
                 cpe_version = re_from_start.sub("", vc)
-
-                # TODO: handle versions such as "1.1.3:p2"
-                # Should work now, I don't know the context of this code.
                 cpe_version = split_cpe_name(cpe_version)[0]
 
-                # TODO: handle versions such as "1.1.3p2"
-                cpe_version = re.search(r"([0-9\.]*)", cpe_version).group(0)
-                if len(cpe_version) == 0:
-                    # TODO: print warnings
-                    # print ("Warning, missing cpe version for {}: '{}'. Skipping cpe.".format(cve["id"], vc))
+                # Simplify equally with the target_version to enable comparison
+                cpe_version_simplified = re.sub(r"[^\d\.]", ".0.", cpe_version)
+                cpe_version_simplified = re.sub(r"[\.]+", ".", cpe_version_simplified)
+                cpe_version_simplified = cpe_version_simplified.strip(".")
+
+                if len(cpe_version_simplified) == 0:
                     continue
-                if target_version_is_included(target_version, cpe_version):
+                if target_version_is_included(
+                    target_version_simplified, cpe_version_simplified
+                ):
                     final_cves.append(cve)
                     break
+
     elif strict_vendor_product:
         # strict product search
 
@@ -264,7 +270,10 @@ def cvesForCPE(
         final_cves = cves
 
     final_cves = sanitize(final_cves)
-    return {"results": final_cves, "total": len(final_cves)}
+    if not notices:
+        return {"results": final_cves, "total": len(final_cves)}
+    else:
+        return {"notices": notices, "results": final_cves, "total": len(final_cves)}
 
 
 # Query Functions

--- a/lib/Query.py
+++ b/lib/Query.py
@@ -14,14 +14,13 @@ import urllib.parse
 
 import requests
 
-from lib.cpe_conversion import split_cpe_name
-
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 
 from lib.Toolkit import toStringFormattedCPE
 from lib.CVEs import CveHandler
 from lib.Config import Configuration
+from lib.cpe_conversion import split_cpe_name
 
 rankinglookup = True
 redisdb = Configuration.getRedisVendorConnection()

--- a/sbin/db_ranking.py
+++ b/sbin/db_ranking.py
@@ -26,13 +26,11 @@ import argparse
 import os
 import sys
 
-from lib.cpe_conversion import split_cpe_name
-
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 
 from lib.DatabaseLayer import addRanking, findRanking, removeRanking
-
+from lib.cpe_conversion import split_cpe_name
 
 def add(cpe=None, key=None, rank=1):
     if cpe is None or key is None:

--- a/sbin/db_ranking.py
+++ b/sbin/db_ranking.py
@@ -32,6 +32,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from lib.DatabaseLayer import addRanking, findRanking, removeRanking
 from lib.cpe_conversion import split_cpe_name
 
+
 def add(cpe=None, key=None, rank=1):
     if cpe is None or key is None:
         return False

--- a/test/unit/test_search.py
+++ b/test/unit/test_search.py
@@ -24,6 +24,38 @@ def test_search_lax(runner):
     assert result.stdout[:20] == "CVE\t: CVE-2017-12231"
 
 
+def test_search_lax_alphanumeric_version(runner):
+    result = runner.runcommand("bin/search.py -p juniper:junos:15.1x53 --lax")
+
+    assert result.returncode == 0
+    assert result.stdout.startswith(
+        "Notice: Target version 15.1x53 simplified as 15.1.0.53 "
+    )
+    assert result.stdout.splitlines()[2] == "CVE\t: CVE-2018-0004"
+
+
+def test_search_lax_complex_version_simplification(runner):
+    result = runner.runcommand('bin/search.py -p "cisco:ios:15.6\(2\)sp2a" --lax')
+
+    assert result.returncode == 0
+    assert result.stdout.splitlines()[0].find(" simplified as 15.6.0.2.0.2.0 ") > 0
+
+
+def test_search_lax_wildcard_version(runner):
+    result = runner.runcommand("bin/search.py -p juniper:junos:* --lax")
+
+    assert result.returncode == 0
+    # A '0' is a fine simplification for a wildcard as zero is below any version.
+    assert result.stdout.startswith("Notice: Target version * simplified as 0 ")
+    assert result.stdout.splitlines()[2] == "CVE\t: CVE-2018-0004"
+
+
+def test_search_lax_missing_version(runner):
+    result = runner.runcommand("bin/search.py -p juniper:junos --lax")
+
+    assert result.returncode == 1
+
+
 def test_search_if_vuln(runner):
     result = runner.runcommand("bin/search.py -p cisco:ios:12.4 --only-if-vulnerable")
 


### PR DESCRIPTION
Work on the issues/TODOs found during https://github.com/cve-search/cve-search/pull/1080#discussion_r1557736118:

- Use simplified version string for easier comparison:
  - Replace any sequence of non-numeric characters with `.0.` in version strings: `1.1.3p2` becomes `1.1.3.0.2`.
  - The extra zero (`.0.`) is for avoiding collisions, e.g., `1.0p1 != 1.0.1` but `1.0p1` => `1.0.0.1 < 1.0.1`.
  - Remove repeated, leading & tailing dots.
- Avoid using `print()` in a library: raising exceptions and adding notices in the returned JSON, instead. This library is used both in `search.py` and in the API. Despite the `lax` is not used by the API, this coding style was a bit dangerous.
- Update documentation for `search.py --lax` option.
- Add unit tests for newly supported use cases.
- Fix documentation on README.md (add missing `-o json`).

Additionally:
- Fix import order bugs after https://github.com/cve-search/cve-search/pull/1080
- Lint README.md markdown, add syntax highlighting for jq & bash and other visual improvements.

Obviously, the simplified version comparison is not exact, but it suits the spirit of the `--lax` *relaxed mode* which will give many false positives by nature.

This handles the TODO for the `p2` case, and should handle it for `\:p2`, too, if there was one, but it seems the `:p2` is correctly positioned as an `update` in `cpe:<cpe_version>:<part>:<vendor>:<product>:<version>:<update>:<edition>:<language>:<sw_edition>:<target_sw>:<target_hw>:<other>`. Also, more resent CVEs has started putting `p2` correctly in the `update` instead of a suffix of `version`.

A good test case, as `CVE-2007-4654` was fixed in OpenSSH 3.0.2p2:
```
$ ./bin/search.py --lax -p "openbsd:openssh:3.0.2p1" | grep "CVE  : CVE-" | wc -l
92
$ ./bin/search.py --lax -p "openbsd:openssh:3.0.2p2" | grep "CVE  : CVE-" | wc -l
91
```

What do you think, @P-T-I & @maxime-huyghe?