### PR TITLE
Avoid dependency conflicts with CveXplore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,25 +7,26 @@ cvexplore==0.3.30
 #   requests         default
 #   tqdm             default
 
-https://github.com/marianoguerra/feedformatter/archive/master.zip
-Flask==2.1.1
-Werkzeug==2.1.1
-Flask-Login==0.6.0
-Flask-restx==1.1.0
-Flask-Breadcrumbs==0.5.1
+cryptography==42.0.4
+dnspython==2.4.2
 Flask-Bootstrap4==4.0.2
+Flask-Breadcrumbs==0.5.1
 Flask-JWT-Extended==4.3.1
-Flask-WTF==1.0.1
-Flask-plugins==1.6.1
+Flask-Login==0.6.0
 flask-menu==0.7.2
-WTForms==3.0.1
+Flask-plugins==1.6.1
+Flask-restx==1.1.0
+Flask-WTF==1.0.1
+Flask==2.1.1
+gunicorn==21.2.0
 Jinja2==3.0.3
-Whoosh==2.7.4
+nested-lookup==0.2.25
+nltk==3.8.1
+oauthlib==3.2.2
 redis==4.5.4
 requirements-parser==0.5.0
-nltk==3.8.1
-nested-lookup==0.2.25
-oauthlib==3.2.2
-dnspython==2.4.2
-gunicorn==21.2.0
-cryptography==42.0.4
+Werkzeug==2.1.1
+Whoosh==2.7.4
+WTForms==3.0.1
+
+https://github.com/marianoguerra/feedformatter/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,12 @@
+cvexplore==0.3.30
+# common dependencies via cvexplore:
+#   ansicolors       default
+#   dicttoxml        default
+#   pymongo          modules/mongodb
+#   python-dateutil  default
+#   requests         default
+#   tqdm             default
+
 https://github.com/marianoguerra/feedformatter/archive/master.zip
 Flask==2.1.1
 Werkzeug==2.1.1
@@ -11,19 +20,12 @@ Flask-plugins==1.6.1
 flask-menu==0.7.2
 WTForms==3.0.1
 Jinja2==3.0.3
-python-dateutil==2.8.2
-requests==2.31.0
 Whoosh==2.7.4
-tqdm~=4.66.1
-pymongo==4.5.0
-dicttoxml==1.7.16
 redis==4.5.4
 requirements-parser==0.5.0
-ansicolors==1.1.8
 nltk==3.8.1
 nested-lookup==0.2.25
 oauthlib==3.2.2
 dnspython==2.4.2
 gunicorn==21.2.0
 cryptography==42.0.4
-cvexplore==0.3.30


### PR DESCRIPTION
From https://github.com/cve-search/cve-search/pull/1094 [job/25211778151](https://github.com/cve-search/cve-search/actions/runs/9170123435/job/25211778151) I noticed that some requirements are `==` pinned in both cve-search & CveXplore:

```
The conflict is caused by:
    The user requested requests==2.32.0
    cvexplore 0.3.30 depends on requests==2.31.0
```

This is apt to cause conflicts at some point, if pinned requirements are ever bumped out-of-sync. This PR moves the responsibility of common requirements from cve-search to CveXplore. The rest of the requirements are reordered alphabetically in a separated commit to make it easier to review the changes; only the requirements handled via CveXplore should be removed from the list.