### PR TITLE
Pass proxy configuration to CveXplore

### DIFF
--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -60,7 +60,6 @@ Backlog: 5
 
 [Proxy]
 http: 
-IgnoreCerts: False
 
 [CVE]
 StartYear: 2002

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -11,6 +11,7 @@
 import bz2
 import configparser
 import gzip
+import json
 import os
 import re
 import ssl
@@ -413,6 +414,22 @@ class Configuration:
     @classmethod
     def getProxy(cls):
         return cls.readSetting("Proxy", "http", cls.default["http_proxy"])
+
+    @classmethod
+    def setProxyEnv(cls):
+        """Sets proxy settings as environment variables for CveXplore"""
+        if cls.getProxy() == "":
+            # Remove environment variables
+            os.environ.pop("HTTP_PROXY_DICT", None)
+            os.environ.pop("HTTP_PROXY_STRING", None)
+        else:
+            # Set environment variables
+            proxyDict = {
+                "http": f"http://{cls.getProxy()}",
+                "https": f"http://{cls.getProxy()}",
+            }
+            os.environ["HTTP_PROXY_DICT"] = json.dumps(proxyDict)
+            os.environ["HTTP_PROXY_STRING"] = f"http://{cls.getProxy()}"
 
     @classmethod
     def ignoreCerts(cls):

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -89,7 +89,6 @@ class Configuration:
         "backlog": 5,
         # [Proxy]
         "http_proxy": "",
-        "http_ignore_certs": False,
         # [CVE]
         "CVEStartYear": 2002,
         # [Plugins]
@@ -432,21 +431,11 @@ class Configuration:
             os.environ["HTTP_PROXY_STRING"] = f"http://{cls.getProxy()}"
 
     @classmethod
-    def ignoreCerts(cls):
-        return cls.readSetting("Proxy", "IgnoreCerts", cls.default["http_ignore_certs"])
-
-    @classmethod
     def getFile(cls, getfile, unpack=True):
         if cls.getProxy():
             proxy = req.ProxyHandler({"http": cls.getProxy(), "https": cls.getProxy()})
             auth = req.HTTPBasicAuthHandler()
             opener = req.build_opener(proxy, auth, req.HTTPHandler)
-            req.install_opener(opener)
-        if cls.ignoreCerts():
-            ctx = ssl.create_default_context()
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-            opener = req.build_opener(urllib.request.HTTPSHandler(context=ctx))
             req.install_opener(opener)
 
         response = req.urlopen(getfile)

--- a/sbin/db_mgmt_capec.py
+++ b/sbin/db_mgmt_capec.py
@@ -11,10 +11,15 @@ import argparse
 import os
 import sys
 
-from CveXplore import CveXplore
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
+
+from lib.Config import Configuration
+
+# pass proxy configuration to CveXplore
+Configuration.setProxyEnv()
+from CveXplore import CveXplore
 
 argparser = argparse.ArgumentParser(
     description="populate/update the local CAPEC database"

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -21,10 +21,16 @@ import argparse
 import os
 import sys
 
-from CveXplore import CveXplore
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
+
+
+from lib.Config import Configuration
+
+# pass proxy configuration to CveXplore
+Configuration.setProxyEnv()
+from CveXplore import CveXplore
 
 # parse command line arguments
 argparser = argparse.ArgumentParser(

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -25,10 +25,15 @@ import argparse
 import os
 import sys
 
-from CveXplore import CveXplore
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
+
+from lib.Config import Configuration
+
+# pass proxy configuration to CveXplore
+Configuration.setProxyEnv()
+from CveXplore import CveXplore
 
 argparser = argparse.ArgumentParser(
     description="populate/update NIST CWE Common Weakness Enumeration database"

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -16,10 +16,15 @@ import argparse
 import os
 import sys
 
-from CveXplore import CveXplore
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
+
+from lib.Config import Configuration
+
+# pass proxy configuration to CveXplore
+Configuration.setProxyEnv()
+from CveXplore import CveXplore
 
 # parse command line arguments
 argparser = argparse.ArgumentParser(

--- a/sbin/db_mgmt_ref.py
+++ b/sbin/db_mgmt_ref.py
@@ -11,10 +11,16 @@ import argparse
 import os
 import sys
 
-from CveXplore import CveXplore
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
+
+
+from lib.Config import Configuration
+
+# pass proxy configuration to CveXplore
+Configuration.setProxyEnv()
+from CveXplore import CveXplore
 
 argparser = argparse.ArgumentParser(
     description="populate/update the local VIA4 database"

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -15,16 +15,21 @@ import subprocess
 import sys
 import time
 
-from CveXplore import CveXplore
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
+
+
+from lib.Config import Configuration
+
+# pass proxy configuration to CveXplore
+Configuration.setProxyEnv()
+from CveXplore import CveXplore
 
 from lib.LogHandler import UpdateHandler
 from lib.Sources_process import (
     CPERedisBrowser,
 )
-from lib.Config import Configuration
 from lib.DatabaseLayer import getSize, dropCollection, getTableNames
 
 logging.setLoggerClass(UpdateHandler)


### PR DESCRIPTION
Fixes #1091

- Adds `Configuration.setProxyEnv()` that sets environment variables used by CveXplore since<br>https://github.com/cve-search/CveXplore/issues/195#issuecomment-1816259408
  ```
  HTTP_PROXY_DICT={'http': 'http://proxy.example.com:8080', 'https': 'http://proxy.example.com:8080'}
  HTTP_PROXY_STRING=http://proxy.example.com:8080
  ```
- Loads `Configuration.setProxyEnv()` before `import CveXplore` to pass the settings in several scripts.
- Removes a configuration parameter that has become unsupported (was only used in `Configuration.getFile()`).
  ```
  [Proxy]
  IgnoreCerts: False
  ```