### PR TITLE
Pass MongoDB configuration to CveXplore

### DIFF
--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -8,7 +8,7 @@ NotificationsDB: 11
 RefDB: 12
 
 [Database]
-Host: localhost
+Host: 127.0.0.1
 Port: 27017
 DB: cvedb
 Username:

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -44,7 +44,7 @@ class Configuration:
         "redisNotificationsDB": 11,
         "redisRefDB": 12,
         # [Database] (MongoDB)
-        "mongoHost": "localhost",
+        "mongoHost": "127.0.0.1",
         "mongoPort": 27017,
         "mongoDB": "cvedb",
         "mongoUsername": "",
@@ -143,9 +143,26 @@ class Configuration:
         return cls.readSetting("Webserver", "MountPath", cls.default["MountPath"])
 
     # Mongo
+
+    @classmethod
+    def getMongoHost(cls):
+        return cls.readSetting("Database", "Host", cls.default["mongoHost"])
+
+    @classmethod
+    def getMongoPort(cls):
+        return cls.readSetting("Database", "Port", cls.default["mongoPort"])
+
     @classmethod
     def getMongoDB(cls):
         return cls.readSetting("Database", "DB", cls.default["mongoDB"])
+
+    @classmethod
+    def getMongoUsername(cls):
+        return cls.readSetting("Database", "Username", cls.default["mongoUsername"])
+
+    @classmethod
+    def getMongoPassword(cls):
+        return cls.readSetting("Database", "Password", cls.default["mongoPassword"])
 
     @classmethod
     def getMongoConnection(cls):
@@ -190,6 +207,22 @@ class Configuration:
             )
 
         return mongoURI
+
+    @classmethod
+    def setMongoDBEnv(cls):
+        """Sets MongoDB settings as environment variables for CveXplore"""
+        os.environ["DATASOURCE_HOST"] = cls.getMongoHost()
+        os.environ["DATASOURCE_PORT"] = str(cls.getMongoPort())
+        os.environ["DATASOURCE_DBNAME"] = cls.getMongoDB()
+
+        # Both username & password should be set to make any sense
+        if cls.getMongoUsername() == "" or cls.getMongoPassword() == "":
+            # Unset environment variables to make CveXplore default to None
+            os.environ.pop("DATASOURCE_USER", None)
+            os.environ.pop("DATASOURCE_PASSWORD", None)
+        else:
+            os.environ["DATASOURCE_USER"] = cls.getMongoUsername()
+            os.environ["DATASOURCE_PASSWORD"] = cls.getMongoPassword()
 
     @classmethod
     def toPath(cls, path):

--- a/sbin/db_mgmt_capec.py
+++ b/sbin/db_mgmt_capec.py
@@ -18,6 +18,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from lib.Config import Configuration
 
 # pass proxy configuration to CveXplore
+Configuration.setMongoDBEnv()
 Configuration.setProxyEnv()
 from CveXplore import CveXplore
 

--- a/sbin/db_mgmt_cpe_dictionary.py
+++ b/sbin/db_mgmt_cpe_dictionary.py
@@ -29,6 +29,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from lib.Config import Configuration
 
 # pass proxy configuration to CveXplore
+Configuration.setMongoDBEnv()
 Configuration.setProxyEnv()
 from CveXplore import CveXplore
 

--- a/sbin/db_mgmt_create_index.py
+++ b/sbin/db_mgmt_create_index.py
@@ -12,6 +12,11 @@ import logging
 import os
 import sys
 
+from lib.Config import Configuration
+
+# pass proxy configuration to CveXplore
+Configuration.setMongoDBEnv()
+Configuration.setProxyEnv()
 from CveXplore.database.maintenance.Sources_process import DatabaseIndexer
 
 runPath = os.path.dirname(os.path.realpath(__file__))

--- a/sbin/db_mgmt_cwe.py
+++ b/sbin/db_mgmt_cwe.py
@@ -32,6 +32,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from lib.Config import Configuration
 
 # pass proxy configuration to CveXplore
+Configuration.setMongoDBEnv()
 Configuration.setProxyEnv()
 from CveXplore import CveXplore
 

--- a/sbin/db_mgmt_json.py
+++ b/sbin/db_mgmt_json.py
@@ -23,6 +23,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from lib.Config import Configuration
 
 # pass proxy configuration to CveXplore
+Configuration.setMongoDBEnv()
 Configuration.setProxyEnv()
 from CveXplore import CveXplore
 

--- a/sbin/db_mgmt_ref.py
+++ b/sbin/db_mgmt_ref.py
@@ -19,6 +19,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from lib.Config import Configuration
 
 # pass proxy configuration to CveXplore
+Configuration.setMongoDBEnv()
 Configuration.setProxyEnv()
 from CveXplore import CveXplore
 

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -23,6 +23,7 @@ sys.path.append(os.path.join(runPath, ".."))
 from lib.Config import Configuration
 
 # pass proxy configuration to CveXplore
+Configuration.setMongoDBEnv()
 Configuration.setProxyEnv()
 from CveXplore import CveXplore
 


### PR DESCRIPTION
- Pass MongoDB configuration as environment variables.
- Unify default MongoDB setting `[Database] Host: 127.0.0.1` with the default of `DATASOURCE_HOST` in CveXplore.