### PR TITLE
Fix default config & remove unused imports

### DIFF
--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -1,7 +1,7 @@
 [Redis]
 Host: localhost
 Port: 6379
-Password: None
+# Password: None
 redisQ: 9
 VendorsDB: 10
 NotificationsDB: 11

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -14,7 +14,6 @@ import gzip
 import json
 import os
 import re
-import ssl
 import urllib.parse
 import urllib.request as req
 import zipfile

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -9,8 +9,6 @@
 
 # imports
 import re
-import sys
-
 import pymongo
 
 from lib.Config import Configuration as conf


### PR DESCRIPTION
- Similar to https://github.com/cve-search/CveXplore/pull/293,<br> `None` is treated as a string. Comment out to keep the default.
- Remove unused `import ssl` from `Config.py` & `import sys` from `DatabaseLayer.py`.