### PR TITLE
Quick fix for sort_dir not working in free queries.

### DIFF
--- a/lib/DatabasePlugins/mongodb.py
+++ b/lib/DatabasePlugins/mongodb.py
@@ -186,7 +186,13 @@ class MongoPlugin(DatabasePluginBase):
                     .find(dict_filter, {"json": 0})
                     .skip(skip)
                 )
-
+        if sort_dir is not None:
+            if sort_dir == "DESC":
+                sort_dir = DESCENDING
+            elif sort_dir == "ASC":
+                sort_dir = ASCENDING
+        else:
+            sort_dir = DESCENDING
         if query_filter is not None:
             if sort is not None:
                 if isinstance(sort, str):
@@ -194,7 +200,7 @@ class MongoPlugin(DatabasePluginBase):
                         resultset = (
                             getattr(self, "store_{}".format(retrieve))
                             .find(dict_filter, query_filter)
-                            .sort(sort, DESCENDING)
+                            .sort(sort, sort_dir)
                             .limit(limit)
                             .skip(skip)
                         )
@@ -202,7 +208,7 @@ class MongoPlugin(DatabasePluginBase):
                         resultset = (
                             getattr(self, "store_{}".format(retrieve))
                             .find(dict_filter, query_filter)
-                            .sort(sort, DESCENDING)
+                            .sort(sort, sort_dir)
                             .skip(skip)
                         )
                 if isinstance(sort, list):

--- a/lib/DatabasePlugins/mongodb.py
+++ b/lib/DatabasePlugins/mongodb.py
@@ -186,11 +186,13 @@ class MongoPlugin(DatabasePluginBase):
                     .find(dict_filter, {"json": 0})
                     .skip(skip)
                 )
-        if sort_dir is not None:
-            if sort_dir == "DESC":
+        if isinstance(sort_dir, str):
+            if sort_dir.startswith("DESC"):
                 sort_dir = DESCENDING
-            elif sort_dir == "ASC":
+            elif sort_dir.startswith("ASC"):
                 sort_dir = ASCENDING
+            else:
+                sort_dir = DESCENDING
         else:
             sort_dir = DESCENDING
         if query_filter is not None:


### PR DESCRIPTION
This quick edit to mongodb.py takes into account the value of sort_dir, rather than assuming it to be DESCENDING.