### PR TITLE
Set sources & update interval manually for NVD API

### DIFF
--- a/docs/source/database/database.rst
+++ b/docs/source/database/database.rst
@@ -97,13 +97,16 @@ NB: If you want to  import your own JSON from VIA4CVE, you have to replace URL i
 
 Updating the database
 ---------------------
-An updater script helps to start the db_mgmt_*
+An updater script helps keeping the databases up-to-date and should be run at regular intervals.
 
 .. code-block:: bash
 
     ./sbin/db_updater.py
 
-You can run it in a crontab, logging is done in log/update_populate.log by default.
+Since CVE-Search v5.0.2 (using CveXplore v0.3.28) the updates have been using all of the sources more wisely; only changed data is downloaded.
+For CPEs and CVEs this means entries that have been added or modified since last update, and for the rest of the source CVE-Search checks
+whether the file has changed before downloading it. Therefore, it is now safe to run this, e.g., every hour. One option is to use crontab.
+Logging is done in log/update_populate.log by default.
 
 These could be also run as a SystemD service and a timer that automates regular updates. Example units are under `_etc/systemd/system/`:
 `cvesearch.db_updater.service <https://github.com/cve-search/cve-search/blob/master/_etc/systemd/system/cvesearch.db_updater.service>`_ &
@@ -114,6 +117,15 @@ These could be also run as a SystemD service and a timer that automates regular 
     sudo systemctl start cvesearch.db_updater.timer
     sudo systemctl enable cvesearch.db_updater.timer
 
+In case some CVEs or CPEs are missing (only) during the last 1–120 days despite you have done regular updates, you can use -d 1..120
+option to avoid repopulating the entire database. This could happen if there have been connectivity issues or other problems with
+the NVD API. E.g., to manually set the update to download entries for the last 7 days from the NVD API:
+
+.. code-block:: bash
+
+    ./sbin/db_updater.py -d 7
+
+Full option list is available with -h / --help.
 
 .. _repop_db:
 

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -95,11 +95,14 @@ def main(args):
         logger.info(
             f'Ignored available CveXplore sources: {", ".join(ignored_sources)}'
         )
+    if len(args.sources) > 0:
+        unavailable_sources = [i for i in args.sources if i not in update_sources]
+        if len(unavailable_sources) > 0:
+            logger.warning(
+                f'Sources unavailable in CveXplore: {", ".join(unavailable_sources)}'
+            )
     if len(update_sources) == 0:
-        if len(args.sources) > 0:
-            logger.error(f"None of the given sources available in CveXplore.")
-        else:
-            logger.error(f"None of the configured sources available in CveXplore.")
+        logger.error(f"None of the sources available in CveXplore.")
         return 1
 
     # Update sources handled by CveXplore

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -56,7 +56,7 @@ def dropcollection(collection=None):
 def main(args):
     cvex = CveXplore()
 
-    if args.f:
+    if args.force:
         logger.info("==========================")
         logger.info("Repopulate")
         logger.info(time.strftime("%a %d %B %Y %H:%M", time.gmtime()))
@@ -65,9 +65,9 @@ def main(args):
         for each in to_drop:
             logger.info(f"Dropping metadata: {each}")
             dropcollection(each)
-        if args.l and args.days == 0:
+        if args.loop and args.days == 0:
             logger.info(
-                "Drop collections (-f) and running in loop (-l) used together; only dropping on the first iteration."
+                "Drop collections (-f, --force) and running in loop (-l, --loop) used together; only dropping on the first iteration."
             )
         logger.info("Starting initial import...")
         cvex.database.initialize()
@@ -76,19 +76,19 @@ def main(args):
     loop_count = 0
 
     while loop:
-        if args.l and args.days > 0:
+        if args.loop and args.days > 0:
             logger.warning(
-                f"Loop (-l) not supported with manual days (-d, --days); only running once"
+                f"Loop (-l, --loop) not supported with manual days (-d, --days); only running once"
             )
-        if not args.l or args.days > 0:
+        if not args.loop or args.days > 0:
             loop = False
         else:
             loop_count += 1
 
         logger.info("==========================")
-        if args.m:
+        if args.minimal:
             redis_info = "; minimal import without redis-cache-cpe source"
-        elif args.c:
+        elif args.cache:
             redis_info = "; CPE redis cache enabled"
         else:
             redis_info = ""
@@ -97,7 +97,7 @@ def main(args):
             loop_info = ""  # loop not supported with manual days
         else:
             days_info = ""
-            if args.l:
+            if args.loop:
                 loop_info = f" (loop #{loop_count})"
             else:
                 loop_info = ""
@@ -105,10 +105,10 @@ def main(args):
         logger.info(time.strftime("%a %d %B %Y %H:%M", time.gmtime()))
         logger.info("==========================")
 
-        if args.c and args.m:
+        if args.cache and args.minimal:
             logger.warning(
-                f"CPE cache enabled (-c) does not do anything when "
-                f"minimal import without redis-cache-cpe source (-m) is used"
+                f"CPE cache enabled (-c, --cache) does not do anything when "
+                f"minimal import without redis-cache-cpe source (-m, --minimal) is used"
             )
 
         cvex.database.update(manual_days=args.days)
@@ -116,7 +116,7 @@ def main(args):
         newelement = 0
         for source in sources:
             # Drop collections only if this was the first iteration of a repopulation
-            if args.f and source["name"] != "redis-cache-cpe" and loop_count < 2:
+            if args.force and source["name"] != "redis-cache-cpe" and loop_count < 2:
                 logger.info("Repopulation; dropping collection: " + source["name"])
                 if dropcollection(collection=source["name"]):
                     logger.info(f"{source['name']} dropped")
@@ -154,13 +154,13 @@ def main(args):
                 )
                 newelement = str(after - before)
                 logger.info(message)
-            elif args.c is True and source["name"] == "redis-cache-cpe":
+            elif args.cache is True and source["name"] == "redis-cache-cpe":
                 logger.info("Starting " + source["name"])
                 up = source["updater"]()
                 up.update()
                 logger.info(source["name"] + " updated")
 
-        if args.i and int(newelement) > 0:
+        if args.index and int(newelement) > 0:
             logger.info("Indexing new cves entries in the fulltext indexer...")
             subprocess.Popen(
                 (
@@ -174,7 +174,7 @@ def main(args):
                 )
             ).wait()
 
-        if args.l and args.days == 0:
+        if args.loop and args.days == 0:
             logger.info("Sleeping 1 hour...")
             time.sleep(3600)
 
@@ -191,27 +191,24 @@ if __name__ == "__main__":
 
     argParser = argparse.ArgumentParser(description="Database updater for cve-search")
     argParser.add_argument(
-        "-v", action="store_true", help="Dummy option for backwards compatibility"
+        "-i",
+        "--index",
+        action="store_true",
+        help="Indexing new CVE entries in the fulltext indexer",
+        default=False,
     )
     argParser.add_argument(
         "-l",
+        "--loop",
         action="store_true",
-        help="Running at regular interval; waits 1 hour (disabled with -d/--days)",
+        help="Running at regular interval; waits 1 hour (disabled with -d, --days)",
         default=False,
-    )
-    argParser.add_argument(
-        "-i",
-        action="store_true",
-        help="Indexing new cves entries in the fulltext indexer",
-        default=False,
-    )
-    argParser.add_argument(
-        "-c", action="store_true", help="Enable CPE redis cache", default=False
     )
     argParser.add_argument(
         "-f",
+        "--force",
         action="store_true",
-        help="Drop collections and force initial import (only on first iteration with -l)",
+        help="Drop collections and force initial import (only on first iteration with -l, --loop)",
         default=False,
     )
     argParser.add_argument(
@@ -224,15 +221,26 @@ if __name__ == "__main__":
         default=0,  # not manually set; updates CPE & CVE since last update
     )
     argParser.add_argument(
-        "-m",
+        "-c",
+        "--cache",
         action="store_true",
-        help="Minimal import without redis-cache-cpe source",
+        help="Enable CPE redis cache (unless -m, --minimal is set)",
         default=False,
+    )
+    argParser.add_argument(
+        "-m",
+        "--minimal",
+        action="store_true",
+        help="Minimal import without redis-cache-cpe source (disables CPE redis cache)",
+        default=False,
+    )
+    argParser.add_argument(
+        "-v", action="store_true", help="Dummy option for backwards compatibility"
     )
 
     args = argParser.parse_args()
 
-    if not args.m:
+    if not args.minimal:
         sources.extend(
             [
                 {"name": "redis-cache-cpe", "updater": CPERedisBrowser},

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -56,6 +56,8 @@ def dropcollection(collection=None):
 def main(args):
     cvex = CveXplore()
 
+    # Repopulation
+
     if args.force:
         logger.info("==========================")
         logger.info("Repopulate")
@@ -72,6 +74,36 @@ def main(args):
         logger.info("Starting initial import...")
         cvex.database.initialize()
 
+    # Get sources from arguments or configuration and compare with sources provided by CveXplore
+
+    update_sources = []
+    ignored_sources = []
+    if len(args.sources) > 0:
+        logger.info(
+            f'Using manually overridden sources instead of configured: {", ".join(args.sources)}'
+        )
+    for source_available in cvex.database.sources:
+        if source_available["name"] in args.sources:
+            update_sources.append(source_available["name"])
+        elif len(args.sources) == 0 and Configuration.includesFeed(
+            source_available["name"]
+        ):
+            update_sources.append(source_available["name"])
+        else:
+            ignored_sources.append(source_available["name"])
+    if len(ignored_sources) > 0:
+        logger.info(
+            f'Ignored available CveXplore sources: {", ".join(ignored_sources)}'
+        )
+    if len(update_sources) == 0:
+        if len(args.sources) > 0:
+            logger.error(f"None of the given sources available in CveXplore.")
+        else:
+            logger.error(f"None of the configured sources available in CveXplore.")
+        return 1
+
+    # Update sources handled by CveXplore
+
     loop = True
     loop_count = 0
 
@@ -87,9 +119,9 @@ def main(args):
 
         logger.info("==========================")
         if args.minimal:
-            redis_info = "; minimal import without redis-cache-cpe source"
+            redis_info = " ; minimal import without redis-cache-cpe source"
         elif args.cache:
-            redis_info = "; CPE redis cache enabled"
+            redis_info = " ; CPE redis cache enabled"
         else:
             redis_info = ""
         if args.days > 0:
@@ -101,7 +133,9 @@ def main(args):
                 loop_info = f" (loop #{loop_count})"
             else:
                 loop_info = ""
-        logger.info(f"Update{redis_info}{loop_info}{days_info}")
+        logger.info(
+            f'Update [{", ".join(update_sources)}]{redis_info}{loop_info}{days_info}'
+        )
         logger.info(time.strftime("%a %d %B %Y %H:%M", time.gmtime()))
         logger.info("==========================")
 
@@ -111,7 +145,9 @@ def main(args):
                 f"minimal import without redis-cache-cpe source (-m, --minimal) is used"
             )
 
-        cvex.database.update(manual_days=args.days)
+        cvex.database.update(update_source=update_sources, manual_days=args.days)
+
+        # Update sources other than CveXplore
 
         newelement = 0
         for source in sources:
@@ -190,6 +226,14 @@ if __name__ == "__main__":
     ]
 
     argParser = argparse.ArgumentParser(description="Database updater for cve-search")
+    argParser.add_argument(
+        "-s",
+        "--sources",
+        nargs="*",
+        metavar="SOURCE",
+        help="Sources to be updated if available in CveXplore. Defaults to all sources available & configured.",
+        default=[],
+    )
     argParser.add_argument(
         "-i",
         "--index",

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -65,7 +65,7 @@ def main(args):
         for each in to_drop:
             logger.info(f"Dropping metadata: {each}")
             dropcollection(each)
-        if args.l:
+        if args.l and args.days == 0:
             logger.info(
                 "Drop collections (-f) and running in loop (-l) used together; only dropping on the first iteration."
             )
@@ -76,7 +76,11 @@ def main(args):
     loop_count = 0
 
     while loop:
-        if not args.l:
+        if args.l and args.days > 0:
+            logger.warning(
+                f"Loop (-l) not supported with manual days (-d, --days); only running once"
+            )
+        if not args.l or args.days > 0:
             loop = False
         else:
             loop_count += 1
@@ -88,11 +92,16 @@ def main(args):
             redis_info = "; CPE redis cache enabled"
         else:
             redis_info = ""
-        if args.l:
-            loop_info = f" (loop #{loop_count})"
+        if args.days > 0:
+            days_info = f" (manual interval of {str(args.days)} days)"
+            loop_info = ""  # loop not supported with manual days
         else:
-            loop_info = ""
-        logger.info(f"Update{redis_info}{loop_info}")
+            days_info = ""
+            if args.l:
+                loop_info = f" (loop #{loop_count})"
+            else:
+                loop_info = ""
+        logger.info(f"Update{redis_info}{loop_info}{days_info}")
         logger.info(time.strftime("%a %d %B %Y %H:%M", time.gmtime()))
         logger.info("==========================")
 
@@ -102,7 +111,7 @@ def main(args):
                 f"minimal import without redis-cache-cpe source (-m) is used"
             )
 
-        cvex.database.update()
+        cvex.database.update(manual_days=args.days)
 
         newelement = 0
         for source in sources:
@@ -165,7 +174,7 @@ def main(args):
                 )
             ).wait()
 
-        if args.l:
+        if args.l and args.days == 0:
             logger.info("Sleeping 1 hour...")
             time.sleep(3600)
 
@@ -185,7 +194,10 @@ if __name__ == "__main__":
         "-v", action="store_true", help="Dummy option for backwards compatibility"
     )
     argParser.add_argument(
-        "-l", action="store_true", help="Running at regular interval", default=False
+        "-l",
+        action="store_true",
+        help="Running at regular interval; waits 1 hour (disabled with -d/--days)",
+        default=False,
     )
     argParser.add_argument(
         "-i",
@@ -199,8 +211,17 @@ if __name__ == "__main__":
     argParser.add_argument(
         "-f",
         action="store_true",
-        help="Drop collections and force initial import",
+        help="Drop collections and force initial import (only on first iteration with -l)",
         default=False,
+    )
+    argParser.add_argument(
+        "-d",
+        "--days",
+        type=int,
+        choices=range(1, 121),
+        metavar="1..120",
+        help="Set update interval (1-120 days) manually for NVD API (CPE, CVE)",
+        default=0,  # not manually set; updates CPE & CVE since last update
     )
     argParser.add_argument(
         "-m",


### PR DESCRIPTION
- [x] Adds `-s` (`--sources`) option for manually overriding sources to be updated using CveXplore
  - also a step towards #1111.
  - [x] breaks EPSS updates without #1112
- [x] Adds `-d` (`--days`) `1..120` options for passing manual interval to CveXplore.
  - [x] Requires CveXplore with https://github.com/cve-search/CveXplore/pull/300.<br>**CAUTION!** It is best to merge this while bumping CveXplore to a version having this feature.
- [x] Add long option strings. Makes the code more readable and the short option strings more understandable and memorable.
- [x] Reorder help; related options grouped together.
- [x] Update documentation.