### PR TITLE
Remove support for search.py -q

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Search for vulnerabilities in the National Vulnerability DB. Data from http://nv
 
 options:
   -h, --help            show this help message and exit
-  -q Q                  Q = search pip requirements file for CVEs, e.g. dep/myreq.txt
-  -p P [P ...]          S = search one or more products, e.g. o:microsoft:windows_7 or o:cisco:ios:12.1 or
+  -p P [P ...]          P = search one or more products, e.g. o:microsoft:windows_7 or o:cisco:ios:12.1 or
                         o:microsoft:windows_7 o:cisco:ios:12.1. Add --only-if-vulnerable if only vulnerabilities that
                         directly affect the product are wanted.
   --only-if-vulnerable  With this option, "-p" will only return vulnerabilities directly assigned to the product. I.e.
@@ -65,6 +64,7 @@ options:
   -s S                  search in summary text
   -t T                  search in last n day
   -i I                  Limit output to n elements (default: unlimited)
+  -q [Q]                Removed. Was used to search pip requirements file for CVEs.
 ```
 
 Examples:

--- a/bin/search.py
+++ b/bin/search.py
@@ -17,7 +17,6 @@ import sys
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
 
-import requirements
 from bson import json_util
 from dicttoxml import dicttoxml
 
@@ -49,13 +48,10 @@ argParser = argparse.ArgumentParser(
     description="Search for vulnerabilities in the National Vulnerability DB. Data from http://nvd.nist.org."
 )
 argParser.add_argument(
-    "-q", type=str, help="Q = search pip requirements file for CVEs, e.g. dep/myreq.txt"
-)
-argParser.add_argument(
     "-p",
     type=str,
     nargs="+",
-    help="S = search one or more products, e.g. o:microsoft:windows_7 or o:cisco:ios:12.1 or o:microsoft:windows_7 "
+    help="P = search one or more products, e.g. o:microsoft:windows_7 or o:cisco:ios:12.1 or o:microsoft:windows_7 "
     "o:cisco:ios:12.1. Add --only-if-vulnerable if only vulnerabilities that directly affect the product are "
     "wanted.",
 )
@@ -113,9 +109,15 @@ argParser.add_argument(
     type=int,
     help="Limit output to n elements (default: unlimited)",
 )
+argParser.add_argument(
+    "-q",
+    type=str,
+    nargs="?",
+    const="removed",
+    help="Removed. Was used to search pip requirements file for CVEs.",
+)
 args = argParser.parse_args()
 
-pyReq = args.q
 vSearch = args.p
 relaxSearch = args.lax
 strict_vendor_product = args.strict_vendor_product
@@ -193,58 +195,12 @@ def is_number(s):
         return False
 
 
-if pyReq:
-    with open(pyReq, "r") as f:
-        for req in requirements.parse(f):
-            lib = req.name
-            specs = req.specs
-            # get vulnerable versions
-            vulns = {}
-            for item in cvesForCPE(lib):
-                if "vulnerable_configuration" in item:
-                    for entry in item["vulnerable_configuration"]:
-                        vulns[vuln_config(entry)] = [
-                            "CVE: " + item["id"],
-                            "DATE: " + str(item["published"]),
-                            "CVSS: " + str(item["cvss"]),
-                            item["summary"],
-                        ]
-            # check if any of those is allowed according to specs
-            found = False
-            for vuln in vulns.keys():
-                sp = split_cpe_name(vuln)
-                ind = -1
-                num = sp[ind]
-                # if the last token is not a number or float then it must be e.g., 'alpha' while the
-                # version number or float must be the second to last, and so on
-                while not is_number(num) and abs(ind) > len(sp):
-                    ind -= 1
-                    num = sp[ind]
-                if is_number(num):
-                    for spec in specs:
-                        if not found:
-                            symbol = spec[0]
-                            curr = spec[1]
-                            if (
-                                (curr == num and "=" in symbol)
-                                or (curr < num and ">" in symbol)
-                                or (curr > num and "<" in symbol)
-                            ):
-                                print(
-                                    "Vulnerability found for "
-                                    + lib
-                                    + ":\n"
-                                    + "version affected: "
-                                    + str(num)
-                                    + "\n"
-                                    + "version in requirements: "
-                                    + symbol
-                                    + str(curr)
-                                    + "\n"
-                                    + str(vulns[vuln])
-                                )
-                                found = True
-    sys.exit(0)
+if args.q:
+    print(
+        "Support for -q (search pip requirements file for CVEs) has been removed",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 # define which output to generate.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ nested-lookup==0.2.25
 nltk==3.8.1
 oauthlib==3.2.2
 redis==4.5.4
-requirements-parser==0.5.0
 Werkzeug==2.1.1
 Whoosh==2.7.4
 WTForms==3.0.1


### PR DESCRIPTION
This feature is broken & depends on a library that is using a deprecated feature. Removing it drops the requirement.

- Resolves https://github.com/cve-search/cve-search/issues/1116