### PR TITLE
feat(search): limit results by days since modified

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           pytest --doctest-modules --junitxml=junit/test-results_${{ matrix.python-version }}.xml --cov-report=xml --cov-report=html --cov=./ test/unit
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results_${{ matrix.python-version }}
           path: junit/test-results_${{ matrix.python-version }}.xml
@@ -136,7 +136,7 @@ jobs:
 #        run: |
 #          pytest --doctest-modules --junitxml=junit/test-results_web_${{ matrix.python-version }}.xml test/web/
 #      - name: Upload pytest test results
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: pytest-results_web_${{ matrix.python-version }}
 #          path: junit/test-results_web_${{ matrix.python-version }}.xml

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ options:
   -a                    Lookup CAPEC for related CWE weaknesses
   -v V                  vendor name to lookup in reference URLs
   -s S                  search in summary text
-  -t T                  search in last n day
+  -t T                  search in last n day (published)
+  -T T                  search in last n day (modified)
   -i I                  Limit output to n elements (default: unlimited)
   -q [Q]                Removed. Was used to search pip requirements file for CVEs.
 ```

--- a/bin/search.py
+++ b/bin/search.py
@@ -33,7 +33,8 @@ csvOutput = 0
 htmlOutput = 0
 jsonOutput = 0
 xmlOutput = 0
-last_ndays = 0
+last_ndays_published = 0
+last_ndays_modified = 0
 nlimit = 0
 
 # init various variables :-)
@@ -102,7 +103,8 @@ argParser.add_argument(
 )
 argParser.add_argument("-v", type=str, help="vendor name to lookup in reference URLs")
 argParser.add_argument("-s", type=str, help="search in summary text")
-argParser.add_argument("-t", type=int, help="search in last n day")
+argParser.add_argument("-t", type=int, help="search in last n day (published)")
+argParser.add_argument("-T", type=int, help="search in last n day (modified)")
 argParser.add_argument(
     "-i",
     default=False,
@@ -129,7 +131,8 @@ sLatest = args.l
 namelookup = args.n
 rankinglookup = args.r
 capeclookup = args.a
-last_ndays = args.t
+last_ndays_published = args.t
+last_ndays_modified = args.T
 summary_text = args.s
 nlimit = args.i
 
@@ -172,12 +175,22 @@ def search_product(prod):
             print(f"{notice}")
         print()  # Empty line to separate the notices from the results.
     for item in ret["results"]:
-        if not last_ndays:
+        if not last_ndays_published and not last_ndays_modified:
             print_job(item)
         else:
-            date_n_days_ago = datetime.now() - timedelta(days=last_ndays)
-            if item["published"] > date_n_days_ago:
-                print_job(item)
+            if last_ndays_published:
+                date_published_n_days_ago = datetime.now() - timedelta(
+                    days=last_ndays_published
+                )
+                if item["published"] > date_published_n_days_ago:
+                    print_job(item)
+                    continue  # Do not show the item twice if both -t and -T are used.
+            if last_ndays_modified:
+                date_modified_n_days_ago = datetime.now() - timedelta(
+                    days=last_ndays_modified
+                )
+                if item["modified"] > date_modified_n_days_ago:
+                    print_job(item)
 
 
 def vuln_config(entry):
@@ -470,29 +483,51 @@ if summary_text:
             if field in item:
                 item[field] = str(item[field])
 
-        if not last_ndays:
+        if not last_ndays_published and not last_ndays_modified:
             if vOutput:
                 printCVE_id(item)
             else:
                 print(json.dumps(item, sort_keys=True, default=json_util.default))
         else:
-            date_n_days_ago = datetime.now() - timedelta(days=last_ndays)
-            # print(item['published'])
-            # print(type (item['published']))
-            # print("Last n day " +str(last_ndays))
-            try:
-                if (
-                    datetime.strptime(item["published"], "%Y-%m-%d %H:%M:%S.%f")
-                    > date_n_days_ago
-                ):
-                    if vOutput:
-                        printCVE_id(item)
-                    else:
-                        print(
-                            json.dumps(item, sort_keys=True, default=json_util.default)
-                        )
-            except:
-                pass
+            if last_ndays_published:
+                date_published_n_days_ago = datetime.now() - timedelta(
+                    days=last_ndays_published
+                )
+                try:
+                    if (
+                        datetime.strptime(item["published"], "%Y-%m-%d %H:%M:%S.%f")
+                        > date_published_n_days_ago
+                    ):
+                        if vOutput:
+                            printCVE_id(item)
+                        else:
+                            print(
+                                json.dumps(
+                                    item, sort_keys=True, default=json_util.default
+                                )
+                            )
+                            continue  # Do not show the item twice if both -t and -T are used.
+                except:
+                    pass
+            if last_ndays_modified:
+                date_modified_n_days_ago = datetime.now() - timedelta(
+                    days=last_ndays_modified
+                )
+                try:
+                    if (
+                        datetime.strptime(item["published"], "%Y-%m-%d %H:%M:%S.%f")
+                        > date_modified_n_days_ago
+                    ):
+                        if vOutput:
+                            printCVE_id(item)
+                        else:
+                            print(
+                                json.dumps(
+                                    item, sort_keys=True, default=json_util.default
+                                )
+                            )
+                except:
+                    pass
     if htmlOutput:
         print("</body></html>")
     sys.exit(0)


### PR DESCRIPTION
Add `search.py -T` to limit results to results from n days by the last modification, while `-t` does it based on the date published.

Resolves https://github.com/cve-search/cve-search/issues/1120