### PR TITLE
WebUI: improve tables

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -36,6 +36,9 @@ a {
     border: 1px dotted #dee2e6;
     line-height: 1.25;
 }
+a .fa-link{
+    display: none;
+}
 .badge a{
     color:white;
 }

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -27,8 +27,14 @@ a {
     padding-top:100px;
     text-align:center;
 }
+.invisiTable{
+    margin: 0px -5px;
+}
 .invisiTable td{
-    padding:0px 5px;
+    padding: 0px 5px;
+    vertical-align: top;
+    border: 1px dotted #dee2e6;
+    line-height: 1.25;
 }
 .badge a{
     color:white;


### PR DESCRIPTION
Solves https://github.com/cve-search/cve-search/issues/1135

- Improve `.invisiTable` tables holding VIA4 references:
  - Vertically align cells to top and add cell borders.
  - Increase line height.
- Hide broken link symbols from the references. (The linked local paths do not hold anything meaningful. Legacy?)