### PR TITLE
Upgrade cvexplore version to newest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cvexplore==0.3.37
+cvexplore==0.3.38
 # common dependencies via cvexplore:
 #   ansicolors       default
 #   dicttoxml        default


### PR DESCRIPTION
I upgraded to cvexplore==0.3.38 because there is a bug in version 0.3.37 https://github.com/cve-search/CveXplore/pull/318 which was fixed in 0.3.38