### PR TITLE
Make the browse endpoint work with products with slashes in their name

### DIFF
--- a/web/restapi/browse_vendor.py
+++ b/web/restapi/browse_vendor.py
@@ -136,7 +136,7 @@ class BrowseAll(Resource):
         return browseList
 
 
-@api.route("/browse/<vendor>/<product>")
+@api.route("/browse/<vendor>/<path:product>")
 @api.response(400, "Error processing request", model=message)
 @api.response(500, "Server error", model=message)
 class BrowseProductVersions(Resource):


### PR DESCRIPTION
For example, `/api/browse/erlang/erlang\/otp` would return a 404 status without this change.

This does nothing for vendors with a slash in their name but is a good first step.