### PR TITLE
Fix warning 'PEP 8 W605 invalid escape sequence'

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -415,7 +415,7 @@ class Configuration:
     @classmethod
     def getMaxLogSize(cls):
         size = cls.readSetting("Logging", "MaxSize", cls.default["maxLogSize"])
-        split = re.findall("\d+|\D+", size)
+        split = re.findall("\\d+|\\D+", size)
         multipliers = {"KB": 1024, "MB": 1024 * 1024, "GB": 1024 * 1024 * 1024}
         if len(split) == 2:
             base = int(split[0])


### PR DESCRIPTION
I got his warning, when running the updater script, based on latest `master` branch...

```
=> [cve-search 17/17] RUN ./sbin/db_updater.py -f                                                                                                                                                                                                                                 6.6s
=> => # /app/sbin/../lib/Config.py:418: SyntaxWarning: invalid escape sequence '\d'
=> => #   split = re.findall("\d+|\D+", size)
```

The change was tested via this test method (below), but I thought it might make no sense to test default values,
so the test is not included in this PR. 

```python
def test_reading_MaxLogSize_default_value_works():
    configuration = Configuration()
    size = configuration.getMaxLogSize()
    assert size == 104857600
```

Any feedback welcome.