### PR TITLE
Update EPSS URL

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -99,7 +99,7 @@ class Configuration:
         "cwe": "https://cwe.mitre.org/data/xml/cwec_latest.xml.zip",
         "capec": "https://capec.mitre.org/data/xml/capec_latest.xml",
         "via4": "https://www.cve-search.org/feeds/via4.json",
-        "epss": "https://epss.cyentia.com/epss_scores-current.csv.gz",
+        "epss": "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz",
     }
 
     included = {


### PR DESCRIPTION
Update `config.py` to the new EPSS URL at https://epss.empiricalsecurity.com/epss_scores-current.csv.gz, https://epss.cyentia.com/epss_scores-current.csv.gz is now dead