### PR TITLE
Bump cvexplore from 0.3.38 to 0.3.39

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cvexplore==0.3.38
+cvexplore==0.3.39
 # common dependencies via cvexplore:
 #   ansicolors       default
 #   dicttoxml        default


### PR DESCRIPTION
CveXplore [v0.3.39](https://github.com/cve-search/CveXplore/releases/tag/v0.3.39):

- Fixes the NVD API bug by enforcing timezone in the timestamp format.
- Updates the schema version, which was mistakenly not bumped after adding CVSSv4 support.

Resolves https://github.com/cve-search/cve-search/issues/1130 https://github.com/cve-search/cve-search/issues/1143