### PR TITLE
Refactor MongoDB configuration: simplify URI construction and pass DnsSrvRecord

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -173,6 +173,16 @@ class Configuration:
         return cls.readSetting("Database", "Password", cls.default["mongoPassword"])
 
     @classmethod
+    def getMongoSrvBool(cls) -> bool:
+        """Returns DnsSrvRecord as a boolean, as configparser.ConfigParser() returns strings"""
+        val = cls.readSetting("Database", "DnsSrvRecord", cls.default["mongoSrv"])
+        return str(val).lower() in ("true", "1", "yes")
+
+    @classmethod
+    def getMongoAuthDB(cls):
+        return cls.readSetting("Database", "AuthDB", cls.default["mongoAuth"])
+
+    @classmethod
     def getMongoConnection(cls):
         # jdt_NOTE: now correctly catches exceptions due to changes in pymongo 2.9 or later
         # jdt_NOTE: https://api.mongodb.com/python/current/migrate-to-pymongo3.html#mongoclient-connects-asynchronously
@@ -181,40 +191,25 @@ class Configuration:
 
     @classmethod
     def getMongoUri(cls):
-        mongoSrv = cls.readSetting("Database", "DnsSrvRecord", cls.default["mongoSrv"])
-        mongoHost = cls.readSetting("Database", "Host", cls.default["mongoHost"])
-        mongoPort = cls.readSetting("Database", "Port", cls.default["mongoPort"])
-        mongoAuth = cls.readSetting("Database", "AuthDB", cls.default["mongoAuth"])
-        mongoDB = cls.getMongoDB()
-        mongoUsername = urllib.parse.quote(
-            cls.readSetting("Database", "Username", cls.default["mongoUsername"])
-        )
-        mongoPassword = urllib.parse.quote(
-            cls.readSetting("Database", "Password", cls.default["mongoPassword"])
-        )
-        if mongoUsername and mongoPassword and mongoSrv is True:
-            mongoURI = "mongodb+srv://{username}:{password}@{host}/{db}?authSource={auth}&retryWrites=true&w=majority".format(
-                username=mongoUsername,
-                password=mongoPassword,
-                host=mongoHost,
-                db=mongoDB,
-                auth=mongoAuth,
+        username = urllib.parse.quote(cls.getMongoUsername())
+        password = urllib.parse.quote(cls.getMongoPassword())
+        host = cls.getMongoHost()
+        port = cls.getMongoPort()
+        db = cls.getMongoDB()
+        auth_db = cls.getMongoAuthDB()
+
+        if username and password and cls.getMongoSrvBool():
+            return (
+                f"mongodb+srv://{username}:{password}@{host}/{db}"
+                f"?authSource={auth_db}&retryWrites=true&w=majority"
             )
-        elif mongoUsername and mongoPassword:
-            mongoURI = "mongodb://{username}:{password}@{host}:{port}/{db}?authSource={auth}".format(
-                username=mongoUsername,
-                password=mongoPassword,
-                host=mongoHost,
-                port=mongoPort,
-                db=mongoDB,
-                auth=mongoAuth,
+        elif username and password:
+            return (
+                f"mongodb://{username}:{password}@{host}:{port}/{db}"
+                f"?authSource={auth_db}"
             )
         else:
-            mongoURI = "mongodb://{host}:{port}/{db}".format(
-                host=mongoHost, port=mongoPort, db=mongoDB
-            )
-
-        return mongoURI
+            return f"mongodb://{host}:{port}/{db}"
 
     @classmethod
     def setMongoDBEnv(cls):

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -218,6 +218,10 @@ class Configuration:
         os.environ["DATASOURCE_PORT"] = str(cls.getMongoPort())
         os.environ["DATASOURCE_DBNAME"] = cls.getMongoDB()
 
+        # Pass DnsSrvRecord configuration
+        if cls.getMongoSrvBool():
+            os.environ["DATASOURCE_DBAPI"] = "srv"
+
         # Both username & password should be set to make any sense
         if cls.getMongoUsername() == "" or cls.getMongoPassword() == "":
             # Unset environment variables to make CveXplore default to None


### PR DESCRIPTION
- [x] Simplifies `getMongoUri()` by using helper functions and f-strings, reducing repetitive code.
- [x] Updates `setMongoDBEnv()` to pass `DATASOURCE_DBAPI=srv` to CveXplore when `DnsSrvRecord` is enabled, fixing previous incorrect behavior.
- [x] Improves clarity and maintainability of MongoDB connection setup.
- [ ] Properly test this on my test environment.

Resolves https://github.com/cve-search/cve-search/issues/1155
