### PR TITLE
test: fix DeprecationWarning by using raw string

### DIFF
--- a/test/unit/test_search.py
+++ b/test/unit/test_search.py
@@ -35,7 +35,7 @@ def test_search_lax_alphanumeric_version(runner):
 
 
 def test_search_lax_complex_version_simplification(runner):
-    result = runner.runcommand('bin/search.py -p "cisco:ios:15.6\(2\)sp2a" --lax')
+    result = runner.runcommand(r'bin/search.py -p "cisco:ios:15.6\(2\)sp2a" --lax')
 
     assert result.returncode == 0
     assert result.stdout.splitlines()[0].find(" simplified as 15.6.0.2.0.2.0 ") > 0


### PR DESCRIPTION
Use a raw string for the search pattern in `test_search.py` to avoid invalid escape sequence warnings with `\(`.