### PR TITLE
Fix handling of CWE as a list in CAPEC lookups

### DIFF
--- a/bin/search.py
+++ b/bin/search.py
@@ -270,8 +270,16 @@ def printCVE_json(item, indent=None):
             if rankinglookup:
                 item["ranking"] = ranking
             if "cwe" in item and capeclookup:
-                if item["cwe"].lower() != "unknown":
-                    item["capec"] = cves.getcapec(cweid=(item["cwe"].split("-")[1]))
+                capec_ids = []
+                for cwe in item["cwe"]:
+                    if cwe.lower() != "unknown":
+                        try:
+                            capec_ids.extend(cves.getcapec(cweid=cwe.split("-")[1]))
+                        except (IndexError, ValueError):
+                            continue
+                if capec_ids:
+                    item["capec"] = capec_ids
+
             print(
                 json.dumps(
                     item, sort_keys=True, default=json_util.default, indent=indent

--- a/lib/CVEs.py
+++ b/lib/CVEs.py
@@ -181,8 +181,16 @@ class CveHandler(object):
                     if len(item["ranking"]) == 0:
                         del item["ranking"]
                 if "cwe" in item and self.capeclookup:
-                    if item["cwe"].lower() != "unknown":
-                        item["capec"] = self.getcapec(cweid=(item["cwe"].split("-")[1]))
+                    capec_ids = []
+                    for cwe in item["cwe"]:
+                        if cwe.lower() != "unknown":
+                            try:
+                                capec_ids.extend(self.getcapec(cweid=cwe.split("-")[1]))
+                            except (IndexError, ValueError):
+                                continue
+                    if capec_ids:
+                        item["capec"] = capec_ids
+
                 entries.append(item)
 
         return entries


### PR DESCRIPTION
CWE values were previously assumed to be strings, but they were changed to a list in CveXplore v0.3.37. This change iterates over CWE lists correctly, fixing the crash and producing combined CAPEC results from all CWE entries.

### Fixes

- the `/api/last` endpoint (as reported in https://github.com/cve-search/cve-search/issues/1162#issuecomment-3212756271)
- the `./bin/search.py` script when using the `-a` (Lookup CAPEC) and `-o json` (JSON output) flags together.

### Tests

```
$ curl --silent http://localhost/api/last | jq '.[5] | {id: .id, cwe: .cwe, capec: [.capec[]?.id]}'
{
  "id": "CVE-2017-20199",
  "cwe": [
    "CWE-266",
    "CWE-284"
  ],
  "capec": [
    "19",
    "441",
    "478",
    . . .
  ]
}
```

```
$ ./bin/search.py -a -p circl:pandora -o json | jq '{id: .id, cwe: .cwe, capec: [.capec[]?.id]}'
{
  "id": "CVE-2023-22898",
  "cwe": [
    "CWE-20"
  ],
  "capec": [
    "10",
    "101",
    "104",
    . . .
  ]
}
```