### PR TITLE
Lazy-load MongoDB connections to improve Gunicorn pre-fork safety

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -14,27 +14,64 @@ import pymongo
 from lib.Config import Configuration as conf
 from lib.cpe_conversion import split_cpe_name
 
-# Variables
-db = conf.getMongoConnection()
-colCVE = db["cves"]
-colCPE = db["cpe"]
-colCWE = db["cwe"]
-colCPEOTHER = db["cpeother"]
-colWHITELIST = db["mgmt_whitelist"]
-colBLACKLIST = db["mgmt_blacklist"]
-colUSERS = db["mgmt_users"]
-colINFO = db["info"]
-colRANKING = db["ranking"]
-colVIA4 = db["via4"]
-colCAPEC = db["capec"]
-colPlugSettings = db["plugin_settings"]
-colPlugUserSettings = db["plugin_user_settings"]
+from functools import lru_cache
 
-mongo_version = db.command("buildinfo")["versionArray"]
-# to check if mongodb > 4.4
-# if it is, then use allow_disk_use for optimized queries
-# to be removed in future with the conditional statements
-# and use allow_disk_use by default
+
+# Lazy DB connection
+@lru_cache(maxsize=1)
+def _get_db():
+    return conf.getMongoConnection()
+
+
+# Lazy DB proxy
+class LazyDB:
+    def __getitem__(self, key):
+        return _get_db()[key]
+
+    def __getattr__(self, key):
+        return getattr(_get_db(), key)
+
+
+db = LazyDB()
+
+
+# Lazy collection proxy
+class LazyCollection:
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def collection(self):
+        return _get_db()[self._name]
+
+    def __getattr__(self, item):
+        return getattr(self.collection, item)
+
+
+# Initialize col* variables as lazy collections to defer DB access
+colCVE = LazyCollection("cves")
+colCPE = LazyCollection("cpe")
+colCWE = LazyCollection("cwe")
+colCPEOTHER = LazyCollection("cpeother")
+colWHITELIST = LazyCollection("mgmt_whitelist")
+colBLACKLIST = LazyCollection("mgmt_blacklist")
+colUSERS = LazyCollection("mgmt_users")
+colINFO = LazyCollection("info")
+colRANKING = LazyCollection("ranking")
+colVIA4 = LazyCollection("via4")
+colCAPEC = LazyCollection("capec")
+colPlugSettings = LazyCollection("plugin_settings")
+colPlugUserSettings = LazyCollection("plugin_user_settings")
+
+
+# mongo_version should be accessed lazily too;
+# this is required to check if mongodb > 4.4
+# - if it is, then use allow_disk_use for optimized queries
+# - in future, the conditional statements can be removed
+#   and allow_disk_use can be used by default
+@lru_cache(maxsize=1)
+def getMongoVersion():
+    return db.command("buildinfo")["versionArray"]
 
 
 # Functions
@@ -105,6 +142,8 @@ def cvesForCPE(
     cpe_searchField = (
         "vulnerable_product" if vulnProdSearch else "vulnerable_configuration"
     )
+
+    mongo_version = getMongoVersion()
 
     # relaxSearch for search.py --lax; Strict search for software version is disabled.
     if lax:
@@ -278,6 +317,7 @@ def cvesForCPE(
 # Generic data
 def getCVEs(limit=False, query=[], skip=0, cves=None, collection=None):
     col = colCVE if not collection else db[collection]
+    mongo_version = getMongoVersion()
     if type(query) == dict:
         query = [query]
     if type(cves) == list:
@@ -336,6 +376,7 @@ def getCVEsNewerThan(dt):
 
 
 def getCVEIDs(limit=-1):
+    mongo_version = getMongoVersion()
     if mongo_version > [4, 4]:
         return [
             x["id"]

--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -64,16 +64,6 @@ colPlugSettings = LazyCollection("plugin_settings")
 colPlugUserSettings = LazyCollection("plugin_user_settings")
 
 
-# mongo_version should be accessed lazily too;
-# this is required to check if mongodb > 4.4
-# - if it is, then use allow_disk_use for optimized queries
-# - in future, the conditional statements can be removed
-#   and allow_disk_use can be used by default
-@lru_cache(maxsize=1)
-def getMongoVersion():
-    return db.command("buildinfo")["versionArray"]
-
-
 # Functions
 def sanitize(x):
     if type(x) == pymongo.cursor.Cursor:
@@ -87,6 +77,15 @@ def sanitize(x):
 
 
 # DB Functions
+def safe_aggregate(collection, pipeline, **kwargs):
+    try:
+        # Use allow_disk_use by default
+        return list(collection.aggregate(pipeline, allowDiskUse=True, **kwargs))
+    except TypeError:
+        # fallback for old MongoDB versions lacking allowDiskUse
+        return list(collection.aggregate(pipeline, **kwargs))
+
+
 def setColUpdate(collection, date):
     colINFO.update({"db": collection}, {"$set": {"lastModified": date}}, upsert=True)
 
@@ -143,8 +142,6 @@ def cvesForCPE(
         "vulnerable_product" if vulnProdSearch else "vulnerable_configuration"
     )
 
-    mongo_version = getMongoVersion()
-
     # relaxSearch for search.py --lax; Strict search for software version is disabled.
     if lax:
         # get target version from product description provided by the user
@@ -175,35 +172,13 @@ def cvesForCPE(
         # over-approximate versions
         cpe_regex = product
 
+        pipeline = [
+            {"$match": {cpe_searchField: {"$regex": cpe_regex}}},
+            {"$sort": {"modified": -1, "cvss": -1} if limit != 0 else {"modified": -1}},
+        ]
         if limit != 0:
-            if mongo_version > [4, 4]:
-                cves = (
-                    colCVE.find({cpe_searchField: {"$regex": cpe_regex}})
-                    .limit(limit)
-                    .sort(
-                        [("modified", pymongo.DESCENDING), ("cvss", pymongo.DESCENDING)]
-                    )
-                    .allow_disk_use(True)
-                )
-            else:
-                cves = (
-                    colCVE.find({cpe_searchField: {"$regex": cpe_regex}})
-                    .limit(limit)
-                    .sort(
-                        [("modified", pymongo.DESCENDING), ("cvss", pymongo.DESCENDING)]
-                    )
-                )
-        else:
-            if mongo_version > [4, 4]:
-                cves = (
-                    colCVE.find({cpe_searchField: {"$regex": cpe_regex}})
-                    .sort("modified", direction=pymongo.DESCENDING)
-                    .allow_disk_use(True)
-                )
-            else:
-                cves = colCVE.find({cpe_searchField: {"$regex": cpe_regex}}).sort(
-                    "modified", direction=pymongo.DESCENDING
-                )
+            pipeline.append({"$limit": limit})
+        cves = safe_aggregate(colCVE, pipeline)
 
         i = 0
 
@@ -240,30 +215,13 @@ def cvesForCPE(
 
         cpe_regex_string = r"^{}".format(re.escape(product))
 
+        pipeline = [
+            {"$match": {"vendors": vendor, "products": {"$regex": cpe_regex_string}}}
+        ]
         if limit != 0:
-            if mongo_version > [4, 4]:
-                cves = (
-                    colCVE.find(
-                        {"vendors": vendor, "products": {"$regex": cpe_regex_string}}
-                    )
-                    .limit(limit)
-                    .sort("cvss", direction=pymongo.DESCENDING)
-                    .allow_disk_use(True)
-                )
-            else:
-                cves = (
-                    colCVE.find(
-                        {"vendors": vendor, "products": {"$regex": cpe_regex_string}}
-                    )
-                    .limit(limit)
-                    .sort("cvss", direction=pymongo.DESCENDING)
-                )
-        else:
-            cves = colCVE.find(
-                {"vendors": vendor, "products": {"$regex": cpe_regex_string}}
-            )
-
-        final_cves = cves
+            pipeline.append({"$sort": {"cvss": -1}})
+            pipeline.append({"$limit": limit})
+        final_cves = safe_aggregate(colCVE, pipeline)
 
     else:
         # create strict cpe regex
@@ -281,30 +239,13 @@ def cvesForCPE(
             cpe_regex_string = "{}".format(re.escape(cpe_regex))
 
         # default strict search
+        pipeline = [
+            {"$match": {cpe_searchField: {"$regex": cpe_regex_string}}},
+            {"$sort": {"cvss": -1}},
+        ]
         if limit != 0:
-            if mongo_version > [4, 4]:
-                cves = (
-                    colCVE.find(
-                        {"{}".format(cpe_searchField): {"$regex": cpe_regex_string}}
-                    )
-                    .limit(limit)
-                    .sort("cvss", direction=pymongo.DESCENDING)
-                    .allow_disk_use(True)
-                )
-            else:
-                cves = (
-                    colCVE.find(
-                        {"{}".format(cpe_searchField): {"$regex": cpe_regex_string}}
-                    )
-                    .limit(limit)
-                    .sort("cvss", direction=pymongo.DESCENDING)
-                )
-        else:
-            cves = colCVE.find(
-                {"{}".format(cpe_searchField): {"$regex": cpe_regex_string}}
-            )
-
-        final_cves = cves
+            pipeline.append({"$limit": limit})
+        final_cves = safe_aggregate(colCVE, pipeline)
 
     final_cves = sanitize(final_cves)
     if not notices:
@@ -315,89 +256,64 @@ def cvesForCPE(
 
 # Query Functions
 # Generic data
-def getCVEs(limit=False, query=[], skip=0, cves=None, collection=None):
-    col = colCVE if not collection else db[collection]
-    mongo_version = getMongoVersion()
-    if type(query) == dict:
-        query = [query]
-    if type(cves) == list:
-        query.append({"id": {"$in": cves}})
-    if len(query) == 0:
-        if mongo_version > [4, 4]:
-            cve = (
-                col.find()
-                .sort("modified", pymongo.DESCENDING)
-                .limit(limit)
-                .skip(skip)
-                .allow_disk_use(True)
-            )
-        else:
-            cve = (
-                col.find().sort("modified", pymongo.DESCENDING).limit(limit).skip(skip)
-            )
-    elif len(query) == 1:
-        if mongo_version > [4, 4]:
-            cve = (
-                col.find(query[0])
-                .sort("modified", pymongo.DESCENDING)
-                .limit(limit)
-                .skip(skip)
-                .allow_disk_use(True)
-            )
-        else:
-            cve = (
-                col.find(query[0])
-                .sort("modified", pymongo.DESCENDING)
-                .limit(limit)
-                .skip(skip)
-            )
-    else:
-        if mongo_version > [4, 4]:
-            cve = (
-                col.find({"$and": query})
-                .sort("modified", pymongo.DESCENDING)
-                .limit(limit)
-                .skip(skip)
-                .allow_disk_use(True)
-            )
-        else:
-            cve = (
-                col.find({"$and": query})
-                .sort("modified", pymongo.DESCENDING)
-                .limit(limit)
-                .skip(skip)
-            )
+def getCVEs(limit=False, query=None, skip=0, cves=None, collection=None):
+    col = colCVE if collection is None else db[collection]
 
-    return {"results": sanitize(cve), "total": len(list(cve))}
+    # Normalize query
+    if query is None:
+        query = []
+    elif isinstance(query, dict):
+        query = [query]
+
+    # Filter by specific CVE IDs if provided
+    if isinstance(cves, list) and cves:
+        query.append({"id": {"$in": cves}})
+
+    # Build aggregation pipeline
+    pipeline = []
+
+    if not query:
+        pipeline.append({"$match": {}})
+    elif len(query) == 1:
+        pipeline.append({"$match": query[0]})
+    else:
+        pipeline.append({"$match": {"$and": query}})
+
+    pipeline.append({"$sort": {"modified": -1}})
+
+    if limit:
+        pipeline.append({"$limit": limit})
+    if skip:
+        pipeline.append({"$skip": skip})
+
+    cve_cursor = safe_aggregate(col, pipeline)
+    cve = list(cve_cursor)
+
+    return {"results": sanitize(cve), "total": len(cve)}
 
 
 def getCVEsNewerThan(dt):
     return getCVEs(query={"lastModified": {"$gt": dt}})
 
 
-def getCVEIDs(limit=-1):
-    mongo_version = getMongoVersion()
-    if mongo_version > [4, 4]:
-        return [
-            x["id"]
-            for x in colCVE.find()
-            .limit(limit)
-            .sort("modified", pymongo.DESCENDING)
-            .allow_disk_use(True)
-        ]
-    else:
-        return [
-            x["id"]
-            for x in colCVE.find().limit(limit).sort("modified", pymongo.DESCENDING)
-        ]
+def getCVEIDs(limit=0):
+    pipeline = [
+        {"$sort": {"modified": -1}},  # -1 is equivalent to pymongo.DESCENDING
+    ]
+    if limit > 0:
+        pipeline.append({"$limit": limit})
+    results = safe_aggregate(colCVE, pipeline)
+    return [x["id"] for x in results]
 
 
-def searchCVE(find_params=None, limit=-1):
-    return (
-        colCVE.find({} if find_params is None else find_params)
-        .limit(limit)
-        .sort("modified", pymongo.DESCENDING)
-    )
+def searchCVE(find_params=None, limit=0):
+    pipeline = [
+        {"$match": {} if find_params is None else find_params},
+        {"$sort": {"modified": -1}},  # -1 is equivalent to pymongo.DESCENDING
+    ]
+    if limit > 0:
+        pipeline.append({"$limit": limit})
+    return safe_aggregate(colCVE, pipeline)
 
 
 def getCVE(id, collection=None):

--- a/web/helpers/flask_database.py
+++ b/web/helpers/flask_database.py
@@ -1,17 +1,45 @@
 from lib.DatabaseHandler import DatabaseHandler
 
 
-class FlaskDatabaseHandler(object):
-    def __init__(self, app=None, **kwargs):
-        self.kwargs = kwargs
+class LazyDatabaseHandler:
+    """
+    Lazily instantiate DatabaseHandler to defer MongoClient creation until first use.
+    This avoids PyMongo warnings when using prefork servers like Gunicorn.
+    """
 
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+        self._real = None
+
+    def _get_real(self):
+        if self._real is None:
+            self._real = DatabaseHandler(**self._kwargs)
+        return self._real
+
+    def __getattr__(self, name):
+        return getattr(self._get_real(), name)
+
+    def __setattr__(self, name, value):
+        if name in ("_real", "_kwargs"):
+            super().__setattr__(name, value)
+        else:
+            setattr(self._get_real(), name, value)
+
+
+class FlaskDatabaseHandler:
+    """
+    Flask helper to attach a lazy DatabaseHandler to `app.dbh`.
+    """
+
+    def __init__(self, app=None, **kwargs):
+        self._lazy_dbh = LazyDatabaseHandler(**kwargs)
         if app is not None:
             self.init_app(app)
 
     def init_app(self, app, **kwargs):
-        self.kwargs.update(kwargs)
-
-        app.dbh = DatabaseHandler()
+        # Merge extra kwargs and attach lazy db handler
+        self._lazy_dbh._kwargs.update(kwargs)
+        app.dbh = self._lazy_dbh
 
     def __repr__(self):
         return "<< FlaskDatabaseHandler >>"

--- a/web/run.py
+++ b/web/run.py
@@ -27,8 +27,8 @@ plugins = PluginManager()
 dbh = FlaskDatabaseHandler()
 
 config = Configuration()
-
-cvex = CveXplore(mongodb_connection_details={"host": config.getMongoUri()})
+config.setMongoDBEnv()  # pass MongoDB settings to CveXplore
+cvex = CveXplore()
 
 app = None
 token_blacklist = None

--- a/web/run.py
+++ b/web/run.py
@@ -27,8 +27,8 @@ plugins = PluginManager()
 dbh = FlaskDatabaseHandler()
 
 config = Configuration()
-config.setMongoDBEnv()  # pass MongoDB settings to CveXplore
-cvex = CveXplore()
+
+cvex = None  # initialize CveXplore later
 
 app = None
 token_blacklist = None
@@ -89,6 +89,14 @@ def create_app(version, run_path):
     login_manager.init_app(app)
     login_manager.login_message = "You must be logged in to access this page!!!"
     login_manager.login_view = "auth.login"
+
+    @app.before_first_request
+    def init_cvexplore():
+        # Defer CveXplore initialization to create MongoClient after fork
+        # (avoids PyMongo 'opened before fork' warning)
+        global cvex
+        config.setMongoDBEnv()  # pass MongoDB settings to CveXplore
+        cvex = CveXplore()
 
     # CORS
     @app.after_request


### PR DESCRIPTION
This PR refactors MongoDB handling across the project to enable **lazy initialization** and ensure **safe operation under Gunicorn's pre-fork model** used by the web interface.

Key improvements include:

- **Lazy-load database connections and collections**: `MongoClient` and collection objects are created only on first access, preventing PyMongo warnings about connections opened before forking.
- **Lazy-load Flask `DatabaseHandler`**: Database connections in Flask are initialized only on the first request, ensuring safe setup under Gunicorn.
- **Deferred CveXplore initialization**: CveXplore now initializes on the first request, with MongoDB configuration provided via environment variables.
- **Simplified aggregation logic**: Removed conditional MongoDB version checks in favor of `safe_aggregate()`, improving readability and maintainability while retaining backward compatibility with very old MongoDB servers that lack `allowDiskUse`.

As a result, this change **fully eliminates** the multiple sources of **the PyMongo warning** in the web interface logs: `UserWarning: MongoClient opened before fork. Create MongoClient only after forking. See PyMongo's documentation for details: https://pymongo.readthedocs.io/en/stable/faq.html#is-pymongo-fork-safe`.