### PR TITLE
lib: lazy-load MongoDB in AuthenticationHandler

### DIFF
--- a/lib/Authentication.py
+++ b/lib/Authentication.py
@@ -44,7 +44,16 @@ class AuthenticationHandler(metaclass=Singleton):
         self.methods = []
         self._load_methods()
         self.api_sessions = {}
-        self.dbh = DatabaseHandler()
+        self._dbh = None
+
+    @property
+    def dbh(self):
+        """
+        Lazily create DatabaseHandler when first accessed.
+        """
+        if self._dbh is None:
+            self._dbh = DatabaseHandler()
+        return self._dbh
 
     def _load_methods(self):
         self.methods = []


### PR DESCRIPTION
Defer MongoDB connection creation until first use to avoid establishing connections in the Gunicorn master process before worker forking.

An addition to lazy-loadings in https://github.com/cve-search/cve-search/pull/1164.