### PR TITLE
web(auth): lazy-load AuthenticationHandler to fix login

### DIFF
--- a/web/helpers/flask_authentication.py
+++ b/web/helpers/flask_authentication.py
@@ -1,17 +1,21 @@
 from lib.Authentication import AuthenticationHandler
 
 
-class FlaskAuthHandler(object):
+class FlaskAuthHandler:
     def __init__(self, app=None, **kwargs):
         self.kwargs = kwargs
-
+        self.auth = None
         if app is not None:
             self.init_app(app)
 
     def init_app(self, app, **kwargs):
         self.kwargs.update(kwargs)
+        app.auth_handler = self
 
-        app.auth_handler = AuthenticationHandler()
+    def __getattr__(self, name):
+        if self.auth is None:
+            self.auth = AuthenticationHandler()
+        return getattr(self.auth, name)
 
     def __repr__(self):
         return "<< FlaskAuthHandler >>"


### PR DESCRIPTION
### Summary

Fixes an `AttributeError` during user login by lazy-loading `AuthenticationHandler` in `FlaskAuthHandler`.

### Problem

`FlaskAuthHandler` did not implement the `isCVESearchUser(id)` method directly. The login route (`route("/login", methods=["GET", "POST"])` in `web/auth.views.py`) uses `lib.User` for user authorization, which called this method, causing an error.

### Solution

This patch adds lazy delegation: `FlaskAuthHandler` now creates an `AuthenticationHandler` instance only when a method like `isCVESearchUser()` is called.

### Impact

- Prevents the login crash due to missing methods.
- Introduces lazy loading, avoiding unnecessary initialization.