### PR TITLE
web(auth): show specific login form errors to user

### DIFF
--- a/web/auth/views.py
+++ b/web/auth/views.py
@@ -156,10 +156,12 @@ def login():
 
         return redirect(url_for("admin.admin_home"))
 
+    status = None
     if form.validate_on_submit():
         # validate username and password
-        username = request.form.get("username")
-        password = request.form.get("password")
+        # Prefer using form data, fallback to raw request.form for legacy/fallback
+        username = form.username.data or request.form.get("username")
+        password = form.password.data or request.form.get("password")
         person = User.get(username, app.auth_handler)
         if person and person.authenticate(password):
             defaultFilters.update(
@@ -172,14 +174,34 @@ def login():
             login_user(person)
             return redirect(url_for("admin.admin_home"))
         else:
-            return render_template(
-                "login.html",
-                form=form,
-                status="wrong_user_pass",
-                show_oidc=config.useOIDC(),
-            )
-    else:
-        return render_template("login.html", form=form, show_oidc=config.useOIDC())
+            status = "wrong_user_pass"
+    elif request.method == "POST":
+        # Handle form errors to produce human readable error messages in GUI (with JS)
+        if "username" in form.errors:
+            if any("required" in e.lower() for e in form.errors["username"]):
+                status = "no_username"
+        elif "password" in form.errors:
+            pw_errors = form.errors["password"]
+            # Empty password ("This field is required.")
+            if any("required" in e.lower() for e in pw_errors):
+                status = "no_password"
+            # "Field must be between <MIN> and <MAX> characters long."
+            elif any("between" in e.lower() for e in pw_errors):
+                status = "invalid_password_length"
+            # Any other error message complaining about password requirements.
+            else:
+                status = "invalid_password_other"
+        elif "csrf_token" in form.errors:
+            status = "csrf_failed"
+        else:
+            status = "form_invalid"
+
+    return render_template(
+        "login.html",
+        form=form,
+        status=status,
+        show_oidc=config.useOIDC(),
+    )
 
 
 # @auth.route("/register", methods=["GET", "POST"])

--- a/web/static/js/custom/statusses.js
+++ b/web/static/js/custom/statusses.js
@@ -40,9 +40,14 @@
       case "invalid_cpe":               showMessage("This cpe is not valid", "error"); break;
       case "cpelist_updated":           showMessage("The rule was updated", "success"); _ok=true;break;
       case "cpelist_update_failed":     showMessage("Failed to update the rule in the " + data["listType"], "error"); break;
-      case "plugin_action_disabled":      showMessage("The plugin is disabled, please restart the webserver", "success"); break;
-      case "plugin_action_enabled":      showMessage("The plugin is enabled, please restart the webserver", "success"); break;
-      case "plugin_action_complete": _ok=true;break;
+      case "plugin_action_disabled":    showMessage("The plugin is disabled, please restart the webserver", "success"); break;
+      case "plugin_action_enabled":     showMessage("The plugin is enabled, please restart the webserver", "success"); break;
+      case "no_username":               showMessage("Please enter a username", "error"); break;
+      case "invalid_password_length":   showMessage("Password length requirements not met", "error"); break;
+      case "invalid_password_other":    showMessage("Password requirements not met (other than length)", "error"); break;
+      case "csrf_failed":               showMessage("CSRF failed. Please reload the page and try again.", "error"); break;
+      case "form_invalid":              showMessage("Form submission failed. Please check your input.", "error"); break;
+      case "plugin_action_complete":    _ok=true;break;
     }
   }
   return _ok;


### PR DESCRIPTION
Login route now detects missing username, invalid/empty password, and CSRF errors, passing status codes to the frontend. JavaScript displays clear messages rather than a generic or no error.

<img width="883" height="534" alt="image" src="https://github.com/user-attachments/assets/f70ef079-f166-4b9c-936f-8990650b4fa1" />

#### Added pop-up error messages

- Please enter a username
- Password length requirements not met
- Password requirements not met (other than length)
- CSRF failed. Please reload the page and try again.
- Form submission failed. Please check your input.

The last is a catch-all error message for other unexpected form errors.