### PR TITLE
lib(query): MongoDB fallback for /api/browse

### DIFF
--- a/lib/Config.py
+++ b/lib/Config.py
@@ -86,6 +86,7 @@ class Configuration:
         "updatelogfile": "./log/update_populate.log",
         "maxLogSize": "100MB",
         "backlog": 5,
+        "redisFallbackWarnings": True,
         # [Proxy]
         "http_proxy": "",
         # [CVE]
@@ -443,6 +444,17 @@ class Configuration:
     @classmethod
     def getBacklog(cls):
         return cls.readSetting("Logging", "Backlog", cls.default["backlog"])
+
+    @classmethod
+    def getRedisFallbackWarnings(cls):
+        value = cls.readSetting(
+            "Logging", "RedisFallbackWarnings", cls.default["redisFallbackWarnings"]
+        )
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in ("true", "1", "yes", "on")
+        return bool(value)
 
     # Download Max Workers
     @classmethod

--- a/lib/Query.py
+++ b/lib/Query.py
@@ -13,15 +13,20 @@ import sys
 import urllib.parse
 
 import requests
+import logging
 
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
+
+from redis.exceptions import ConnectionError, TimeoutError, RedisError
 
 from lib.Toolkit import toStringFormattedCPE
 from lib.CVEs import CveHandler
 from lib.Config import Configuration
 from lib.cpe_conversion import split_cpe_name
+from lib.DatabaseHandler import DatabaseHandler
 
+logger = logging.getLogger(__name__)
 rankinglookup = True
 redisdb = Configuration.getRedisVendorConnection()
 
@@ -99,26 +104,85 @@ def qcvesForCPE(cpe, limit=0):
 
 def getBrowseList(vendor):
     result = {}
-    if (vendor is None) or type(vendor) == list:
-        v1 = redisdb.smembers("o")
-        v2 = redisdb.smembers("a")
-        v3 = redisdb.smembers("h")
-        vendor = sorted(list(set(list(v1) + list(v2) + list(v3))))
-        cpe = None
-    else:
-        cpenum = redisdb.scard("v:" + vendor)
-        if cpenum < 1:
-            return None
-        p = redisdb.smembers("v:" + vendor)
-        cpe = sorted(list(p))
+    mongoFallback = False
+    try:
+        if (vendor is None) or type(vendor) == list:
+            v1 = redisdb.smembers("o")
+            v2 = redisdb.smembers("a")
+            v3 = redisdb.smembers("h")
+            if v1 or v2 or v3:
+                vendor = sorted(list(set(list(v1) + list(v2) + list(v3))))
+                cpe = None
+            else:
+                mongoFallback = True
+                if Configuration.getRedisFallbackWarnings():
+                    logger.warning(
+                        "Redis cache empty when fetching vendor list. Falling back to MongoDB."
+                    )
+        else:
+            cpenum = redisdb.scard("v:" + vendor)
+            if cpenum < 1:
+                mongoFallback = True
+                if Configuration.getRedisFallbackWarnings():
+                    logger.warning(
+                        f"Redis cache returned nothing when fetching products "
+                        f'for vendor "{vendor}". Falling back to MongoDB.'
+                    )
+            else:
+                p = redisdb.smembers("v:" + vendor)
+                cpe = sorted(list(p))
+    except (ConnectionError, TimeoutError, RedisError) as e:
+        mongoFallback = True
+        if Configuration.getRedisFallbackWarnings():
+            logger.warning(f"Redis error: {e}; Falling back to MongoDB.")
+
+    if mongoFallback:
+        dbh = DatabaseHandler()
+        if (vendor is None) or type(vendor) == list:
+            vendor = sorted(filter(None, dbh.connection.store_cves.distinct("vendors")))
+            cpe = None
+        else:
+            cpe = sorted(
+                filter(
+                    None,
+                    dbh.connection.store_cves.distinct("products", {"vendors": vendor}),
+                )
+            )
+
     result["vendor"] = vendor
     result["product"] = cpe
     return result
 
 
 def getVersionsOfProduct(product):
-    p = redisdb.smembers("p:" + product)
-    return sorted(list(p))
+    mongoFallback = False
+    try:
+        p = redisdb.smembers("p:" + product)
+        if not p:
+            mongoFallback = True
+            if Configuration.getRedisFallbackWarnings():
+                logger.warning(
+                    f"Redis cache empty when fetching versions for product {product}. "
+                    f"Falling back to MongoDB."
+                )
+        else:
+            return sorted(list(p))
+    except (ConnectionError, TimeoutError, RedisError) as e:
+        mongoFallback = True
+        if Configuration.getRedisFallbackWarnings():
+            logger.warning(f"Redis error: {e}. Falling back to MongoDB.")
+
+    if mongoFallback:
+        dbh = DatabaseHandler()
+        docs = dbh.connection.store_cpe.find(
+            {"product": product},
+            {"cpeName": 1, "stem": 1, "_id": 0},
+        )
+        versions = []
+        versions.extend(
+            doc["cpeName"][len(doc["stem"]) + 1 :] for doc in docs if "cpeName" in doc
+        )
+        return sorted(versions)
 
 
 def searchVendors(vendor_part):


### PR DESCRIPTION
- Fallback to MongoDB when Redis cache is unavailable or empty in
  - `getVersionsOfProduct(product)`
  - `getBrowseList(vendor)`
- New configuration parameter `[Logging]` / `RedisFallbackWarnings`
  - Setting it to `False` can be used to suppress fallback warnings if Redis is intentionally not in use.