### PR TITLE
Update legacy documentation and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can search the database using search.py.
 usage: search.py [-h] [-q Q] [-p P [P ...]] [--only-if-vulnerable] [--strict_vendor_product] [--lax] [-f F] [-c C] [-o O]
                  [-l] [-n] [-r] [-a] [-v V] [-s S] [-t T] [-i I]
 
-Search for vulnerabilities in the National Vulnerability DB. Data from http://nvd.nist.org.
+Search for vulnerabilities in the National Vulnerability DB. Data from https://nvd.nist.gov/.
 
 options:
   -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ cve-search includes a back-end to store vulnerabilities and related information,
 an intuitive web interface for search and managing vulnerabilities,
 a series of tools to query the system and a web API interface.
 
-cve-search is used by many organizations including the [public CVE services of CIRCL](https://cvepremium.circl.lu/).
+cve-search is used by many organizations. The [public CVE services of CIRCL](https://cve.circl.lu/)
+were also powered by cve-search, but they have since been superseded by
+[Vulnerability-Lookup](https://www.vulnerability-lookup.org/).
 
 This document gives you basic information how to start with cve-search. For more
 information please refer to the documentation in the **_/doc_** folder of this
@@ -214,7 +216,10 @@ Once started, open your browser and navigate to `http://127.0.0.1:5000/`.
 ## Web API interface
 
 The web interface includes a minimal JSON API to get CVE by ID, by vendor or product.
-A public version of the API is also accessible on [cve.circl.lu](https://cve.circl.lu/).
+
+The public API at [cve.circl.lu](https://cve.circl.lu/) has replaced cve-search
+with [Vulnerability-Lookup](https://www.vulnerability-lookup.org/), but the
+[API](https://cve.circl.lu/api/) remains mostly backwards compatible.
 
 List the know vendors in JSON
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,7 @@ Or dump the last 2 CVE entries in RSS or Atom format.
 ./bin/dump_last.py -f atom -l 2
 ```
 
-Or you can use the webinterface.
-
-```bash
-./web/index.py
-```
+Or you can use the [web interface](#web-interface) or [web API](#web-api-interface).
 
 ## Usage of the ranking database
 

--- a/README.md
+++ b/README.md
@@ -177,21 +177,37 @@ or to query the fulltext index and output the JSON object for each CVE-ID:
 ./bin/search_fulltext.py -q NFS -q Linux -f
 ```
 
-## Fulltext visualization
+### Fulltext visualization
 
-The fulltext indexer visualization is using the fulltext indexes to build
-a list of the most common keywords used in CVE. [NLTK](http://nltk.org/) is
-required to generate the keywords with the most common English
-stopwords and lemmatize the output. [NTLK for Python 3](http://nltk.org/nltk3-alpha/)
-exists but you need to use the alpha version of NLTK.
+The fulltext indexer can be used to generate JSON data of the most common
+keywords in CVE entries. It uses [NLTK](https://www.nltk.org/) to lemmatize
+words (convert to base forms) and to filter out common English stopwords.
+
+Run the script to generate the JSON:
 
 ```bash
-./bin/search_fulltext.py  -g -s >cve.json
+./bin/search_fulltext.py  -g -s > cve.json
 ```
 
-![cve-search visualization](https://farm9.staticflickr.com/8109/8603509755_c7690c2de4_n.jpg "CVE Keywords Visualization Using Data From cve-search")
+The resulting `cve.json` contains a flat hierarchy:
 
-You can see a visualization on the [demo site](http://www.foo.be/cve/).
+```json
+{
+  "name": "cve-search",
+  "children": [
+    {"name": "vulnerability", "size": 4855},
+    {"name": "allow", "size": 2544},
+    {"name": "file", "size": 2240},
+    ...
+  ]
+}
+```
+
+The script **does not create the visualizations**, but the `cve.json` can be
+used as source data for visualization tools such as D3-hierarchy
+[Pack](https://d3js.org/d3-hierarchy/pack) diagrams or word cloud generators.
+
+![cve-search visualization](https://farm9.staticflickr.com/8109/8603509755_c7690c2de4_n.jpg "CVE Keywords Visualization Using Data From cve-search")
 
 ## Web interface
 

--- a/README.md
+++ b/README.md
@@ -197,17 +197,19 @@ You can see a visualization on the [demo site](http://www.foo.be/cve/).
 
 ## Web interface
 
-The web interface is a minimal interface to see the last CVE entries and
-query a specific CVE. You'll need flask in order to run the website and
-[Flask-PyMongo](http://flask-pymongo.readthedocs.org/en/latest/). To start
-the web interface:
+The web interface provides an intiutive way to browse the most recent CVE
+entries and look up details about a specific CVE. Comprehensive instructions for
+configuring and deploying the web interface  as a **SystemD service** or an
+**uWSGI application** are available in the
+[WebGUI documentation](https://cve-search.github.io/cve-search/webgui/webgui.html).  
+
+To launch the web interface quickly for testing purposes, run:
 
 ```bash
-cd ./web
-./index.py
+python3 ./web/index.py
 ```
 
-Then you can connect on `http://127.0.0.1:5000/` to browser the last CVE.
+Once started, open your browser and navigate to `http://127.0.0.1:5000/`.
 
 ## Web API interface
 

--- a/bin/dump_last.py
+++ b/bin/dump_last.py
@@ -47,7 +47,7 @@ if args.l:
 else:
     last_items = 10
 
-ref = "http://adulau.github.com/cve-search/"
+ref = "https://github.com/cve-search/cve-search/"
 cvelist = CveHandler(rankinglookup=args.r, namelookup=args.n, capeclookup=args.c)
 
 if not (args.f == "html"):
@@ -61,9 +61,9 @@ if not (args.f == "html"):
         + " CVE entries generated on "
         + str(datetime.datetime.now())
     )
-    feed.feed["link"] = "http://adulau.github.com/cve-search/"
+    feed.feed["link"] = "https://github.com/cve-search/cve-search/"
     feed.feed["author"] = (
-        "Generated with cve-search available at http://adulau.github.com/cve-search/"
+        "Generated with cve-search available at https://github.com/cve-search/cve-search/"
     )
     feed.feed["description"] = ""
 else:

--- a/bin/dump_last.py
+++ b/bin/dump_last.py
@@ -93,7 +93,7 @@ for x in cvelist.get(limit=last_items):
         if x["references"]:
             item["link"] = str(x["references"][0])
         else:
-            item["link"] = "http://web.nvd.nist.gov/view/vuln/detail?vulnId=" + x["id"]
+            item["link"] = "https://nvd.nist.gov/vuln/detail/" + x["id"]
         feed.items.append(item)
     else:
         print('<div class="cve"><table><tbody>')

--- a/bin/search.py
+++ b/bin/search.py
@@ -46,7 +46,7 @@ summary_text = ""
 
 # parse command-line arguments
 argParser = argparse.ArgumentParser(
-    description="Search for vulnerabilities in the National Vulnerability DB. Data from http://nvd.nist.org."
+    description="Search for vulnerabilities in the National Vulnerability DB. Data from https://nvd.nist.gov/."
 )
 argParser.add_argument(
     "-p",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,7 +27,9 @@ CVE-Search includes a back-end to store vulnerabilities and related information,
 an intuitive web interface for search and managing vulnerabilities,
 a series of tools to query the system and a web API interface.
 
-CVE-Search is used by many organizations including the `public CVE services of CIRCL <https://cve.circl.lu/>`_.
+CVE-Search is used by many organizations. The the `public CVE services of CIRCL <https://cve.circl.lu/>`_
+were also powered by cve-search, but they have since been superseded by
+`Vulnerability-Lookup <https://www.vulnerability-lookup.org/>`_.
 
 This document gives you basic information how to start with CVE-Search.
 

--- a/web/templates/layouts/auth_base.html
+++ b/web/templates/layouts/auth_base.html
@@ -4,7 +4,7 @@
     <!-- metadata -->
     <meta charset="UTF-8">
     <title>{% block title %}{% endblock %} - CVE-Search</title>
-    <meta name="author" content="http://github.com/cve-search/cve-search - cve-search"/>
+    <meta name="author" content="https://github.com/cve-search/cve-search/ - cve-search"/>
 
     <!-- css -->
     <link href="{{ url_for('static', filename='css/bootstrap.min.css') }}" rel="stylesheet">

--- a/web/templates/layouts/master-page.html
+++ b/web/templates/layouts/master-page.html
@@ -4,7 +4,7 @@
     <!-- metadata -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="author" content="http://github.com/cve-search/cve-search - cve-search"/>
+    <meta name="author" content="https://github.com/cve-search/cve-search/ - cve-search"/>
 
     <!-- css -->
     <link href="{{ url_for('static', filename='css/bootstrap.min.css') }}" rel="stylesheet">


### PR DESCRIPTION
- Fixed broken, non-canonical, and non-TLS URLs.
- Updated web interface documentation in `README.md`.
- Replaced a non-working example command with references to up-to-date documentation.
- Noted that [Vulnerability-Lookup](https://www.vulnerability-lookup.org/) has replaced cve-search in CIRCL’s public CVE services.
- Clarify how the fulltext visualization works, without promising too much.