### PR TITLE
web(admin): prevent <defunct> processes in /updatedb

### DIFF
--- a/web/admin/views.py
+++ b/web/admin/views.py
@@ -1,12 +1,9 @@
 import os
-import re
 import threading
 import subprocess
 import sys
-import urllib
-from io import BytesIO
 
-from flask import render_template, request, jsonify, send_file, url_for
+from flask import render_template, request, jsonify, url_for
 from flask_breadcrumbs import default_breadcrumb_root, register_breadcrumb
 from flask_login import current_user, login_required
 from flask_plugins import (
@@ -17,7 +14,6 @@ from flask_plugins import (
 )
 
 from lib.Config import Configuration
-from lib.Query import getVersionsOfProduct
 from lib.DatabaseLayer import any_lock_active, colLOCKS
 from web.home.utils import adminInfo
 from . import admin


### PR DESCRIPTION
Child processes spawned by the `/updatedb` endpoint could become zombies if not properly reaped. This change runs them in a daemon thread that waits for completion, ensuring the process table stays clean while forwarding logs and keeping the endpoint non-blocking.

This is not a bug introduced in [!1176](https://github.com/cve-search/cve-search/pull/1176); it existed before, but is now easier to notice as the feature is more appealing to use. :smile_cat: 