### PR TITLE
fix(db): index creation script integration

### DIFF
--- a/sbin/db_mgmt_create_index.py
+++ b/sbin/db_mgmt_create_index.py
@@ -28,6 +28,21 @@ logging.setLoggerClass(UpdateHandler)
 # pass configuration to CveXplore
 Configuration.setCveXploreEnv()
 
+
+class DatabaseWrapper:
+    """
+    Adapt a raw pymongo Database object for CveXplore's DatabaseIndexer that
+    expect a '.dbclient' attribute exposing the underlying MongoDB database.
+    Unfortunately, the 'Configuration.getMongoConnection()' already returns a
+    'pymongo.database.Database' instance, which does not define '.dbclient'.
+    This wrapper resolves that mismatch.
+    """
+
+    def __init__(self, db):
+        self.dbclient = db
+
+
 if __name__ == "__main__":
-    di = DatabaseIndexer(Configuration.getMongoConnection())
+    db = Configuration.getMongoConnection()
+    di = DatabaseIndexer(DatabaseWrapper(db))
     di.create_indexes()


### PR DESCRIPTION
Unfortunately, the fix on https://github.com/cve-search/cve-search/pull/1178 was incomplete, introducing a new bug. :disappointed: 

### :bug: Root cause

`DatabaseIndexer` expects a `.dbclient` attribute, but `getMongoConnection()` returns a raw Database object. This causes MongoDB to interpret `.dbclient` as a prefix for collection names, creating phantom `dbclient.*` collections:

```
cvedb> show collections
capec
cpe
cpeother
cves
cwe
dbclient.capec
dbclient.cpe
dbclient.cpeother
dbclient.cves
dbclient.cwe
dbclient.mgmt_blacklist
dbclient.mgmt_whitelist
dbclient.via4
info
mgmt_blacklist
mgmt_users
mgmt_whitelist
schema
updaterLocks
via4

cvedb> db.dbclient.cpe.getIndexes()
[
  { v: 2, key: { _id: 1 }, name: '_id_' },
  { v: 2, key: { id: 1 }, name: 'id', unique: true },
  { v: 2, key: { vendor: 1 }, name: 'vendor' },
  { v: 2, key: { product: 1 }, name: 'product' },
  { v: 2, key: { deprecated: 1 }, name: 'deprecated' },
  { v: 2, key: { cpeName: 1 }, name: 'cpeName' },
  { v: 2, key: { title: 1 }, name: 'title' },
  { v: 2, key: { stem: 1 }, name: 'stem' },
  { v: 2, key: { padded_version: 1 }, name: 'padded_version' },
  { v: 2, key: { lastModified: 1 }, name: 'lastModified' }
]
``` 

### :bulb: Solution

Introduce a lightweight `DatabaseWrapper` that exposes the raw Database object under `.dbclient`. This ensures indexes are created in the correct database without generating phantom collections.

### :test_tube: Testing

1. Drop existing indexes on `cpe`:

    ```
    cvedb> db.cpe.getIndexes()
    [
      { v: 2, key: { _id: 1 }, name: '_id_' },
      { v: 2, key: { id: 1 }, name: 'id', unique: true },
      { v: 2, key: { vendor: 1 }, name: 'vendor' },
      { v: 2, key: { product: 1 }, name: 'product' },
      { v: 2, key: { deprecated: 1 }, name: 'deprecated' },
      { v: 2, key: { cpeName: 1 }, name: 'cpeName' },
      { v: 2, key: { title: 1 }, name: 'title' },
      { v: 2, key: { stem: 1 }, name: 'stem' },
      { v: 2, key: { padded_version: 1 }, name: 'padded_version' },
      { v: 2, key: { lastModified: 1 }, name: 'lastModified' }
    ]
    cvedb> db.cpe.dropIndexes()
    {
      nIndexesWas: 10,
      msg: 'non-_id indexes dropped for collection',
      ok: 1
    }
    cvedb> db.cpe.getIndexes()
    [ { v: 2, key: { _id: 1 }, name: '_id_' } ]

    ```
2. Run the index creation script:
    ```
    $ ./sbin/db_mgmt_create_index.py
    ```
    - Script now runs slightly longer because all indexes are being recreated.

3. Verify indexes are restored correctly:
     ```
    cvedb> db.cpe.getIndexes()
    [
      { v: 2, key: { _id: 1 }, name: '_id_' },
      { v: 2, key: { id: 1 }, name: 'id', unique: true },
      { v: 2, key: { vendor: 1 }, name: 'vendor' },
      { v: 2, key: { product: 1 }, name: 'product' },
      { v: 2, key: { deprecated: 1 }, name: 'deprecated' },
      { v: 2, key: { cpeName: 1 }, name: 'cpeName' },
      { v: 2, key: { title: 1 }, name: 'title' },
      { v: 2, key: { stem: 1 }, name: 'stem' },
      { v: 2, key: { padded_version: 1 }, name: 'padded_version' },
      { v: 2, key: { lastModified: 1 }, name: 'lastModified' }
    ]
    ```
 4. Verify no phantom collections exist:
    ```
    cvedb> show collections
    capec
    cpe
    cpeother
    cves
    cwe
    info
    mgmt_blacklist
    mgmt_users
    mgmt_whitelist
    schema
    updaterLocks
    via4
    ```
