### PR TITLE
fix(db): modernize ranking functions for PyMongo 4.x

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -448,30 +448,30 @@ def getDBStats(include_admin=False):
 def addRanking(cpe, key, rank):
     item = findRanking(cpe)
     if item is None:
-        colRANKING.update({"cpe": cpe}, {"$push": {"rank": {key: rank}}}, upsert=True)
+        colRANKING.update_one(
+            {"cpe": cpe}, {"$push": {"rank": {key: rank}}}, upsert=True
+        )
     else:
         l = []
         for i in item["rank"]:
             i[key] = rank
             l.append(i)
-        colRANKING.update({"cpe": cpe}, {"$set": {"rank": l}})
+        colRANKING.update_one({"cpe": cpe}, {"$set": {"rank": l}})
     return True
 
 
 def removeRanking(cpe):
-    return sanitize(colRANKING.remove({"cpe": {"$regex": cpe, "$options": "i"}}))
+    return sanitize(colRANKING.delete_one({"cpe": {"$regex": cpe, "$options": "i"}}))
 
 
 def findRanking(cpe=None, regex=False):
     if not cpe:
-        # return sanitize(colRANKING.find())
-        return None
+        return sanitize(colRANKING.find())
     if regex:
-        # return sanitize(colRANKING.find_one({'cpe': {'$regex': cpe}}))
-        return None
+        safe_cpe = re.escape(cpe)  # escape all regex meta characters
+        return sanitize(colRANKING.find_one({"cpe": {"$regex": safe_cpe}}))
     else:
-        return None
-        # return sanitize(colRANKING.find_one({'cpe': cpe}))
+        return sanitize(colRANKING.find_one({"cpe": cpe}))
 
 
 # Per-source locking helpers.


### PR DESCRIPTION
- Replace deprecated `update()` and `remove()` with `update_one()` and `delete_one()`.
- Fix `findRanking()` to return actual results, including regex support, restoring the intended ranking feature behavior.
  - The ranking feature was intentionally left broken in commit 1765ced4d97718c39222a0f9a7e8aafda19675e0 to speed up initial imports. At the time, the import pipeline lacked the optimizations later provided by the CveXplore library as the backend.
  - Escape special characters in CPE strings when using regex searches in `findRanking()` to prevent MongoDB errors with `*` and other regex meta-characters.
- Fully restore the operation of the `./sbin/db_ranking.py` ranking value editor, bringing the feature back to its intended functionality.
