### PR TITLE
db(update): separate fulltext indexing from database updates

### DIFF
--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -231,7 +231,6 @@ def main(args):
 
         # Update sources other than CveXplore
 
-        newelement = 0
         for source in sources:
             if not acquire_lock(source["name"]):
                 logger.warning(
@@ -280,7 +279,6 @@ def main(args):
                         + str(after - before)
                         + " update)"
                     )
-                    newelement = str(after - before)
                     logger.info(message)
                 elif args.cache is True and source["name"] == "redis-cache-cpe":
                     logger.info("Starting " + source["name"])
@@ -291,31 +289,10 @@ def main(args):
                 release_lock(source["name"])
 
         if args.index:
-            if int(newelement) > 0:
-                if not acquire_lock("fulltext-indexer"):
-                    logger.warning(
-                        f"Fulltext indexer is already locked by another update, skipping indexing"
-                    )
-                else:
-                    try:
-                        logger.info(
-                            "Indexing new cves entries in the fulltext indexer..."
-                        )
-                        subprocess.Popen(
-                            (
-                                shlex.split(
-                                    "{} {} {}".format(
-                                        sys.executable,
-                                        os.path.join(runPath, "db_fulltext.py"),
-                                        "-v -l " + newelement,
-                                    )
-                                )
-                            )
-                        ).wait()
-                    finally:
-                        release_lock("fulltext-indexer")
-            else:
-                logger.info("No new cves to add in the fulltext indexer...")
+            logger.warning(
+                "Fulltext indexing has been removed from db_updater.py. "
+                "Use db_fulltext.py to manage fulltext index."
+            )
 
         if args.loop and args.days == 0:
             logger.info("Sleeping 1 hour...")
@@ -345,7 +322,10 @@ if __name__ == "__main__":
         "-i",
         "--index",
         action="store_true",
-        help="Indexing new CVE entries in the fulltext indexer",
+        help=(
+            "Dummy option for backwards compatibility. ",
+            "Use sbin/db_fulltext.py for indexing CVE entries in the fulltext indexer",
+        ),
         default=False,
     )
     argParser.add_argument(

--- a/web/admin/views.py
+++ b/web/admin/views.py
@@ -72,7 +72,7 @@ def updatedb():
         os.path.join(app.config["run_path"], "../sbin/db_updater.py"),
     ]
 
-    flags = {"cache": "-c", "index": "-i"}
+    flags = {"cache": "-c"}
     for arg, flag in flags.items():
         if request.args.get(arg, "false").lower() == "true":
             args.append(flag)

--- a/web/static/js/custom/admin.js
+++ b/web/static/js/custom/admin.js
@@ -5,9 +5,6 @@ function updateDB() {
   if (document.getElementById("updateCache")?.checked) {
     data.cache = true;
   }
-  if (document.getElementById("updateIndex")?.checked) {
-    data.index = true;
-  }
 
   const checkedInputs = document.querySelectorAll(
     '#updateSources input[type="checkbox"]:checked'

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -152,10 +152,6 @@
             <input class="form-check-input" type="checkbox" id="updateCache">
             <label class="form-check-label" for="updateCache">Populate Redis cache (always a full update)</label>
           </div>
-          <div class="form-check">
-            <input class="form-check-input" type="checkbox" id="updateIndex">
-            <label class="form-check-label" for="updateIndex">Fulltext index new CVE entries</label>
-          </div>
         </div>
         <button class="btn btn-primary btn-sm" onclick="updateDB()" class="margin_left">
           Start update


### PR DESCRIPTION
The fulltext indexing feature in `db_updater.py` previously relied on being able to read the number of updated CVEs during the process. With the CveXplore backend, this information is no longer available, making the update operation effectively a no-op. This commit removes indexing from the script and the admin UI, leaving a hint on the current usage.

The fulltext indexing is still available through `./sbin/db_fulltext.py` and searchable via `./bin/search_fulltext.py`.