### PR TITLE
fix(search): output limit in search.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Check the [documentation](https://cve-search.github.io/cve-search/) to get you s
 You can search the database using search.py.
 
 ```text
-usage: search.py [-h] [-q Q] [-p P [P ...]] [--only-if-vulnerable] [--strict_vendor_product] [--lax] [-f F] [-c C] [-o O]
+usage: search.py [-h] [-p P [P ...]] [--only-if-vulnerable] [--strict_vendor_product] [--lax] [-f F] [-c C] [-o O]
                  [-l] [-n] [-r] [-a] [-v V] [-s S] [-t T] [-i I]
 
 Search for vulnerabilities in the National Vulnerability DB. Data from https://nvd.nist.gov/.
@@ -67,7 +67,6 @@ options:
   -t T                  search in last n day (published)
   -T T                  search in last n day (modified)
   -i I                  Limit output to n elements (default: unlimited)
-  -q [Q]                Removed. Was used to search pip requirements file for CVEs.
 ```
 
 Examples:

--- a/bin/search.py
+++ b/bin/search.py
@@ -111,13 +111,6 @@ argParser.add_argument(
     type=int,
     help="Limit output to n elements (default: unlimited)",
 )
-argParser.add_argument(
-    "-q",
-    type=str,
-    nargs="?",
-    const="removed",
-    help="Removed. Was used to search pip requirements file for CVEs.",
-)
 args = argParser.parse_args()
 
 vSearch = args.p
@@ -209,14 +202,6 @@ def is_number(s):
         return ret
     except ValueError:
         return False
-
-
-if args.q:
-    print(
-        "Support for -q (search pip requirements file for CVEs) has been removed",
-        file=sys.stderr,
-    )
-    sys.exit(1)
 
 
 # define which output to generate.

--- a/bin/search.py
+++ b/bin/search.py
@@ -167,9 +167,12 @@ def search_product(prod):
             lax=relaxSearch,
             vulnProdSearch=vulnerableProductSearch,
             strict_vendor_product=True,
+            limit=nlimit,
         )
     else:
-        ret = cvesForCPE(prod, lax=relaxSearch, vulnProdSearch=vulnerableProductSearch)
+        ret = cvesForCPE(
+            prod, lax=relaxSearch, vulnProdSearch=vulnerableProductSearch, limit=nlimit
+        )
     if "notices" in ret:
         for notice in ret["notices"]:
             print(f"{notice}")
@@ -449,7 +452,7 @@ def search_in_summary(item):
 
 
 if cveSearch:
-    for item in getCVEs(cves=cveSearch)["results"]:
+    for item in getCVEs(cves=cveSearch, limit=nlimit)["results"]:
         print_job(item)
     if htmlOutput:
         print("</body></html>")

--- a/bin/search.py
+++ b/bin/search.py
@@ -23,7 +23,7 @@ from dicttoxml import dicttoxml
 runPath = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(runPath, ".."))
 
-from lib.DatabaseLayer import cvesForCPE, getCVEs, getFreeText, getCVEIDs, searchCVE
+from lib.DatabaseLayer import cvesForCPE, getCVEs, getFreeText, searchCVE
 from lib.CVEs import CveHandler
 from lib.cpe_conversion import split_cpe_name
 


### PR DESCRIPTION
- Fix search result limiting by passing `-i` limit to `lib.DatabaseLayer` functions that supports it.
- Cleanup unused import.
- Remove documentation of flag `-q` that was removed in https://github.com/cve-search/cve-search/pull/1117.