### PR TITLE
cleanup(db): simplify db_updater.py

### DIFF
--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -180,9 +180,7 @@ def main(args):
             loop_count += 1
 
         logger.info("==========================")
-        if args.minimal:
-            redis_info = " ; minimal import without redis-cache-cpe source"
-        elif args.cache:
+        if args.cache:
             redis_info = " ; CPE redis cache enabled"
         else:
             redis_info = ""
@@ -200,12 +198,6 @@ def main(args):
         )
         logger.info(time.strftime("%a %d %B %Y %H:%M", time.gmtime()))
         logger.info("==========================")
-
-        if args.cache and args.minimal:
-            logger.warning(
-                f"CPE cache enabled (-c, --cache) does not do anything when "
-                f"minimal import without redis-cache-cpe source (-m, --minimal) is used"
-            )
 
         locked_sources, failed_source = _acquire_all_locks_or_none(update_sources)
         if not locked_sources:
@@ -355,19 +347,12 @@ if __name__ == "__main__":
         "-c",
         "--cache",
         action="store_true",
-        help="Enable CPE redis cache (unless -m, --minimal is set)",
-        default=False,
-    )
-    argParser.add_argument(
-        "-m",
-        "--minimal",
-        action="store_true",
-        help="Minimal import without redis-cache-cpe source (disables CPE redis cache)",
+        help="Enable CPE redis cache",
         default=False,
     )
     args = argParser.parse_args()
 
-    if not args.minimal:
+    if args.cache:
         sources.extend(
             [
                 {"name": "redis-cache-cpe", "updater": CPERedisBrowser},

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -223,6 +223,22 @@ def main(args):
 
         # Update sources other than CveXplore
 
+        sources = [
+            {
+                "name": "cpeother",
+                "updater": "{} {}".format(
+                    sys.executable,
+                    os.path.join(runPath, "db_mgmt_cpe_other_dictionary.py"),
+                ),
+            },
+        ]
+        if args.cache:
+            sources.extend(
+                [
+                    {"name": "redis-cache-cpe", "updater": CPERedisBrowser},
+                ]
+            )
+
         for source in sources:
             if not acquire_lock(source["name"]):
                 logger.warning(
@@ -292,15 +308,6 @@ def main(args):
 
 
 if __name__ == "__main__":
-    sources = [
-        {
-            "name": "cpeother",
-            "updater": "{} {}".format(
-                sys.executable, os.path.join(runPath, "db_mgmt_cpe_other_dictionary.py")
-            ),
-        },
-    ]
-
     argParser = argparse.ArgumentParser(description="Database updater for cve-search")
     argParser.add_argument(
         "-s",
@@ -351,12 +358,5 @@ if __name__ == "__main__":
         default=False,
     )
     args = argParser.parse_args()
-
-    if args.cache:
-        sources.extend(
-            [
-                {"name": "redis-cache-cpe", "updater": CPERedisBrowser},
-            ]
-        )
 
     main(args)

--- a/sbin/db_updater.py
+++ b/sbin/db_updater.py
@@ -365,10 +365,6 @@ if __name__ == "__main__":
         help="Minimal import without redis-cache-cpe source (disables CPE redis cache)",
         default=False,
     )
-    argParser.add_argument(
-        "-v", action="store_true", help="Dummy option for backwards compatibility"
-    )
-
     args = argParser.parse_args()
 
     if not args.minimal:


### PR DESCRIPTION
- **Remove dummy flag**: The dummy flag `-v` is not required anymore for admin UI compatibility, as the usage of it was removed in https://github.com/cve-search/cve-search/pull/1176 commit https://github.com/cve-search/cve-search/commit/e958732eb6acd6957034c181ff4bd8b687458a5d.
- **Remove redundant flag**: The flag `-m` / `--minimal` was nothing but the opposite of `-c` / `--cache`. We don't need two flags for toggling the exactly same feature.
- **Reorder code to be more readable**: Move additional sources population closer to where it is processed.