### PR TITLE
Update dependencies: CveXplore, Gunicorn, Werkzeug etc.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cvexplore==0.3.39
+cvexplore==0.3.40
 # common dependencies via cvexplore:
 #   ansicolors       default
 #   dicttoxml        default

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cvexplore==0.3.40
 #   tqdm             default
 
 cryptography==44.0.1
-dnspython==2.4.2
+dnspython==2.6.1
 Flask-Bootstrap4==4.0.2
 Flask-Breadcrumbs==0.5.1
 Flask-Login==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ flask-menu==0.7.2
 Flask-plugins==1.6.1
 Flask-restx==1.1.0
 Flask-WTF==1.0.1
-Flask==2.1.1
+Flask==2.2.5
 gunicorn==23.0.0
 Jinja2==3.0.3
 nested-lookup==0.2.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Flask-Login==0.6.3
 flask-menu==0.7.2
 Flask-plugins==1.6.1
 Flask-restx==1.1.0
-Flask-WTF==1.0.1
+Flask-WTF==1.2.0
 Flask==2.2.5
 gunicorn==23.0.0
 Jinja2==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Flask-plugins==1.6.1
 Flask-restx==1.1.0
 Flask-WTF==1.0.1
 Flask==2.1.1
-gunicorn==21.2.0
+gunicorn==23.0.0
 Jinja2==3.0.3
 nested-lookup==0.2.25
 nltk==3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cvexplore==0.3.40
 #   requests         default
 #   tqdm             default
 
-cryptography==42.0.4
+cryptography==44.0.1
 dnspython==2.4.2
 Flask-Bootstrap4==4.0.2
 Flask-Breadcrumbs==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cryptography==42.0.4
 dnspython==2.4.2
 Flask-Bootstrap4==4.0.2
 Flask-Breadcrumbs==0.5.1
-Flask-Login==0.6.0
+Flask-Login==0.6.3
 flask-menu==0.7.2
 Flask-plugins==1.6.1
 Flask-restx==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ nested-lookup==0.2.25
 nltk==3.9
 oauthlib==3.2.2
 redis==4.5.4
-Werkzeug==2.1.1
+Werkzeug==3.0.6
 Whoosh==2.7.4
 WTForms==3.0.1
 


### PR DESCRIPTION
Update some vulnerable dependencies as well as CveXplore, which upgrades the database model after retiring the whitelist/blacklist.

### What this PR fixes

- bump **cvexplore from 0.3.39 to 0.3.40**
  - CveXplore 0.3.40 retires the whitelist/blacklist feature, fixes URI construction, enforces time zones in NVD API timestamp formats, and bumps the schema version after adding CVSSv4.
- bump **gunicorn from 21.2.0 to 23.0.0**
  - CVE-2024-6827 (7.5) HTTP Request/Response Smuggling (HRS) vulnerability
  - CVE-2024-1135 (8.2) HRS leading to endpoint restriction bypass
- bump **Werkzeug from 2.1.1 to 3.0.6**
  - CVE-2024-34069 (7.5) RCE interacting with attacker controlled domain
  - CVE-2023-25577 (7.5) High resource usage parsing multipart form data
  - CVE-2024-49767 (6.9) Resource exhaustion parsing file data in forms
  - CVE-2024-49766 (6.3) Werkzeug safe_join not safe on Windows
  - CVE-2023-46136 (5.7) DoS parsing large multipart starting with CR/LF
  - CVE-2023-23934 (2.6) __Host- cookies bypass with nameless cookies
- bump **Flask from 2.1.1 to 2.2.5**
  - CVE-2023-30861 (8.7) Flask vulnerable to possible disclosure of permanent session cookie due to missing Vary: Cookie header.
- bump **Flask-Login from 0.6.0 to 0.6.3**
  - Fixes version mismatch between Flask-Login and Werkzeug (>=2.1).
- bump **Flask-WTF from 1.0.1 to 1.2.0**
  - Fixes version mismatch between Flask-WTF and Werkzeug (>=2.1).
- bump **cryptography from 42.0.4 to 44.0.1**
  - GHSA-h4gh-qq45-vh27 Vulnerable OpenSSL included in cryptography wheels
  - CVE-2024-12797 Vulnerable OpenSSL included in cryptography wheels
- bump **dnspython from 2.4.2 to 2.6.1**
  - CVE-2023-29483 (5.9): Potential DoS via the Tudoor mechanism

### What vulnerabilities remain unpatched

It’s possible that Dependabot is disabled due to numerous false-positive alerts and because it recommends updating dependencies that are incompatible with some of the unmaintained packages we still use. In particular, `Flask-plugins==1.6.1` prevents upgrading Jinja2, which contains several known vulnerabilities. The only way to fully resolve this issue would be to remove the plugin feature entirely. The Jinja2 vulnerabilities we cannot yet fix:

- CVE-2025-27516 (5.4) sandbox breakout through attr filter
- CVE-2024-56201 (5.4) sandbox breakout through malicious filenames
- CVE-2024-56326 (5.4) sandbox breakout through indirect reference
- CVE-2024-34064 (5.4) HTML attribute injection in xmlattr filter
- CVE-2024-22195 (5.4) HTML attribute injection in xmlattr filter
