### PR TITLE
web(admin): render template sections dynamically

### DIFF
--- a/lib/DatabaseLayer.py
+++ b/lib/DatabaseLayer.py
@@ -426,7 +426,7 @@ def via4Linked(key, val):
 
 
 def getDBStats(include_admin=False):
-    data = {"cves": {}, "cpe": {}, "cpeOther": {}, "capec": {}, "cwe": {}, "via4": {}}
+    data = {"cves": {}, "cpe": {}, "cpeother": {}, "capec": {}, "cwe": {}, "via4": {}}
     for key in data.keys():
         data[key] = {
             "size": getSize(key.lower()),

--- a/web/admin/views.py
+++ b/web/admin/views.py
@@ -30,12 +30,13 @@ def admin_home():
         "via4": config.includesFeed("via4"),
         "epss": config.includesFeed("epss"),
     }
+    show_pwd_form = config.loginRequired() and not config.useOIDC()
     return render_template(
         "admin.html",
         status="default",
         feeds=feeds,
         **adminInfo(),
-        disable_pwd_section=config.useOIDC(),
+        show_pwd_form=show_pwd_form,
     )
 
 

--- a/web/admin/views.py
+++ b/web/admin/views.py
@@ -22,9 +22,18 @@ default_breadcrumb_root(admin, ".Admin")
 @register_breadcrumb(admin, ".", "Admin")
 @login_required
 def admin_home():
+    feeds = {
+        "cpe": config.includesFeed("cpe"),
+        "cve": config.includesFeed("cve"),
+        "cwe": config.includesFeed("cwe"),
+        "capec": config.includesFeed("capec"),
+        "via4": config.includesFeed("via4"),
+        "epss": config.includesFeed("epss"),
+    }
     return render_template(
         "admin.html",
         status="default",
+        feeds=feeds,
         **adminInfo(),
         disable_pwd_section=config.useOIDC(),
     )

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -90,36 +90,16 @@
         <div class="form-group" id="updateSources">
           <p>Sources to update (defaults to configured):</p>
           <div class="row">
+            {% for feed in feeds.items()|batch(2) %}
             <div class="col-md-4">
+              {% for source, enabled in feed %}
               <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="sourceCPE" value="cpe">
-                <label class="form-check-label" for="sourceCPE">CPE</label>
+                <input class="form-check-input" type="checkbox" id="source{{ source|upper }}" value="{{ source }}"{% if enabled %} checked{% endif %}>
+                <label class="form-check-label" for="source{{ source|upper }}">{{ source|upper }}</label>
               </div>
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="sourceCVE" value="cve">
-                <label class="form-check-label" for="sourceCVE">CVE</label>
-              </div>
+              {% endfor %}
             </div>
-            <div class="col-md-4">
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="sourceCWE" value="cwe">
-                <label class="form-check-label" for="sourceCWE">CWE</label>
-              </div>
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="sourceCAPEC" value="capec">
-                <label class="form-check-label" for="sourceCAPEC">CAPEC</label>
-              </div>
-            </div>
-            <div class="col-md-4">
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="sourceVIA4" value="via4">
-                <label class="form-check-label" for="sourceVIA4">VIA4</label>
-              </div>
-              <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="sourceEPSS" value="epss">
-                <label class="form-check-label" for="sourceEPSS">EPSS</label>
-              </div>
-            </div>
+            {% endfor %}
           </div>
         </div>
         <div class="form-group">

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -28,48 +28,19 @@
               </tr>
             </thead>
             <tbody>
+              {% for key, values in stats['data'].items() %}
               <tr>
-                <td>CVES</td>
-                <td>{{stats['data']['cves']['size']}} </td>
-                <td>{% if stats['data']['cves']['last_update'] is not none %}
-                  {{stats['data']['cves']['last_update'].strftime('%d-%m-%Y - %H:%M')}} {% else %}Not updated{% endif %}
+                <td>{{ key }}</td>
+                <td>{{ values['size'] }}</td>
+                <td>
+                  {% if values['last_update'] is not none %}
+                    {{ values['last_update'].strftime('%d-%m-%Y - %H:%M') }}
+                  {% else %}
+                    Not updated
+                  {% endif %}
                 </td>
-              <tr>
-              <tr>
-                <td>CPE</td>
-                <td>{{stats['data']['cpe']['size']}} </td>
-                <td>{% if stats['data']['cpe']['last_update'] is not none %}
-                  {{stats['data']['cpe']['last_update'].strftime('%d-%m-%Y - %H:%M')}} {% else %}Not updated{% endif %}
-                </td>
-              <tr>
-              <tr>
-                <td>CPE-other</td>
-                <td>{{stats['data']['cpeOther']['size']}}</td>
-                <td>{% if stats['data']['cpeOther']['last_update'] is not none %}
-                  {{stats['data']['cpeOther']['last_update'].strftime('%d-%m-%Y - %H:%M')}} {% else %}Not updated{% endif
-                  %}</td>
-              <tr>
-              <tr>
-                <td>Capec</td>
-                <td>{{stats['data']['capec']['size']}} </td>
-                <td>{% if stats['data']['capec']['last_update'] is not none %}
-                  {{stats['data']['capec']['last_update'].strftime('%d-%m-%Y - %H:%M')}} {% else %}Not updated{% endif %}
-                </td>
-              <tr>
-              <tr>
-                <td>CWE</td>
-                <td>{{stats['data']['cwe']['size']}} </td>
-                <td>{% if stats['data']['cwe']['last_update'] is not none %}
-                  {{stats['data']['cwe']['last_update'].strftime('%d-%m-%Y - %H:%M')}} {% else %}Not updated{% endif %}
-                </td>
-              <tr>
-              <tr>
-                <td>via4</td>
-                <td>{{stats['data']['via4']['size']}} </td>
-                <td>{% if stats['data']['via4']['last_update'] is not none %}
-                  {{stats['data']['via4']['last_update'].strftime('%d-%m-%Y - %H:%M')}} {% else %}Not updated{% endif %}
-                </td>
-              <tr>
+              </tr>
+              {% endfor %}
             </tbody>
           </table>
         </div>

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -96,7 +96,7 @@
   </div>
     <div class="col-md-4">
     <!-- Change password -->
-    {% if not disable_pwd_section %}
+    {% if show_pwd_form %}
     <div class="card">
       <div class="card-header">
         <strong>Change your password</strong>


### PR DESCRIPTION
### Changes

- Refactor the admin template to generate
  - **source checkboxes** in a loop instead of hardcoding each one. Checkboxes are now automatically selected if their source is enabled in the configuration, so the UI defaults match the configured update sources.
  - **database statistics** rows in a loop instead of hardcoding each one. This reduces duplication and makes the table easier to maintain when adding or removing data sources.
  - **password form only when login is required** and internal user database in use (no OIDC configured).

### Example

With the following configuration in `./etc/sources.ini`:

```
[EnabledFeeds]
cpe: True
cve: True
cwe: True
capec: True
via4: False
epss: False
```

the modified sections of the admin page are rendered as follows:

<img width="817" height="491" alt="image" src="https://github.com/user-attachments/assets/b1d08b4b-fb16-43e9-8fe0-c6ff920f4556" />

