### PR TITLE
cleanup: remove unused imports, setting, and schema_version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ tmp/
 indexdir/
 
 etc/configuration.ini
+etc/sources.ini
+etc/auth.txt
 
 docs/build/
 

--- a/etc/.schema_version
+++ b/etc/.schema_version
@@ -1,4 +1,0 @@
-{
-    "version": "1.3",
-    "rebuild_needed": true
-}

--- a/etc/configuration.ini.sample
+++ b/etc/configuration.ini.sample
@@ -32,7 +32,6 @@ Debug: True
 SSLDebug: False
 PageLength: 50
 LoginRequired: False
-ListLoginRequired: True
 authSettings: ./etc/auth.txt
 OIDC: False
 CLIENT_ID: xx

--- a/lib/Config.py
+++ b/lib/Config.py
@@ -63,7 +63,6 @@ class Configuration:
         "flaskSSLDebug": False,
         "pageLength": 50,
         "loginRequired": False,
-        "listLogin": True,
         "auth_load": "./etc/auth.txt",
         "oidc": False,
         "client_id": "xx",
@@ -343,12 +342,6 @@ class Configuration:
     def loginRequired(cls):
         return cls.readSetting(
             "Webserver", "LoginRequired", cls.default["loginRequired"]
-        )
-
-    @classmethod
-    def listLoginRequired(cls):
-        return cls.readSetting(
-            "Webserver", "ListLoginRequired", cls.default["listLogin"]
         )
 
     @classmethod

--- a/lib/DatabasePlugins/mongodb.py
+++ b/lib/DatabasePlugins/mongodb.py
@@ -1,6 +1,5 @@
 import re
 import sre_constants
-import urllib
 from collections import defaultdict
 
 import bson

--- a/lib/Query.py
+++ b/lib/Query.py
@@ -10,9 +10,6 @@
 
 import os
 import sys
-import urllib.parse
-
-import requests
 import logging
 
 runPath = os.path.dirname(os.path.realpath(__file__))

--- a/web/auth/views.py
+++ b/web/auth/views.py
@@ -12,7 +12,6 @@ from lib.LogHandler import AppLogger
 from lib.User import User
 from . import auth
 from .forms import LoginForm
-from ..home.utils import defaultFilters
 from ..run import oidcClient, config, app
 
 logging.setLoggerClass(AppLogger)

--- a/web/home/utils.py
+++ b/web/home/utils.py
@@ -1,11 +1,7 @@
 import re
 from html import escape
-
 from flask import request
-from flask_login import current_user
-
 from lib.Config import Configuration
-from lib.Toolkit import tk_compile
 from web.helpers.common import timestringTOdatetime
 
 config = Configuration()

--- a/web/home/utils.py
+++ b/web/home/utils.py
@@ -18,7 +18,6 @@ defaultFilters = {
 
 config_args = {
     "pageLength": config.getPageLength(),
-    "listLogin": config.listLoginRequired(),
     "minimal": True,
 }
 

--- a/web/home/views.py
+++ b/web/home/views.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 from flask import render_template, request, make_response, json, jsonify, url_for
 from flask_breadcrumbs import register_breadcrumb, default_breadcrumb_root
-from flask_login import current_user
 
 from lib.CVEs import CveHandler
 from . import home


### PR DESCRIPTION
This PR cleans up unused code and files:

- Remove unused imports from `web/` and `lib/`.
- Remove the unused `ListLoginRequired` setting from the configuration.
- Remove the unused `.schema_version` file, which has been handled via the CveXplore library for some time.
- Add expected configuration files to `.gitignore`.

This PR was split from https://github.com/cve-search/cve-search/pull/1192 because of scope differences: this PR focuses on cleanup, while the other contains the admin template improvements.