### PR TITLE
Revert "build(deps): bump werkzeug from 3.0.6 to 3.1.4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ nested-lookup==0.2.25
 nltk==3.9.1
 oauthlib==3.2.2
 redis==4.5.4
-Werkzeug==3.1.4
+Werkzeug==3.0.6
 Whoosh==2.7.4
 WTForms==3.0.1
 


### PR DESCRIPTION
Reverts cve-search/cve-search#1197

Several other dependencies are incompatible with Werkzeug 3.1.x. The current dependencies are properly tested with 3.0.6.

- Flask 2.2.5 is not compatible with Werkzeug 3.1.x (officially supports ≤2.3.x)
- Flask-Breadcrumbs and flask-menu rely on APIs removed in newer Flask/Werkzeug.
- Flask-restx 1.3.0 uses request APIs removed in Werkzeug 3.1.
- Flask-WTF is not verified for Flask/Werkzeug 3.x.