### PR TITLE
cleanup(deps): drop unused cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cvexplore==0.3.40
 #   python-dateutil  default
 #   requests         default
 #   tqdm             default
+#   urllib3          default
 
 dnspython==2.6.1
 Flask-Bootstrap4==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ cvexplore==0.3.40
 #   requests         default
 #   tqdm             default
 
-cryptography==44.0.1
 dnspython==2.6.1
 Flask-Bootstrap4==4.0.2
 Flask-Breadcrumbs==0.5.1


### PR DESCRIPTION
- Remove the direct dependency on cryptography, which is not imported anywhere in the codebase and appears to be used only transitively through other dependencies. (`grep -E "(import|from) cryptography" -rs .` is empty.)
- Document urllib3 dependency; urllib3 is imported directly in web/auth/views.py. Document it in requirements.txt to reflect the project's dependency on it, even though it is provided through CveXplore and not declared separately.
   ```
   ./web/auth/views.py:from urllib3 import Retry
   ```