### PR TITLE
build(deps): bump cvexplore from 0.3.40 to 0.3.41

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cvexplore==0.3.40
+cvexplore==0.3.41
 # common dependencies via cvexplore:
 #   ansicolors       default
 #   dicttoxml        default


### PR DESCRIPTION
CveXplore [v0.3.41](https://github.com/cve-search/CveXplore/releases/tag/v0.3.41):
- https://github.com/cve-search/CveXplore/pull/340
  - Resolves https://github.com/cve-search/cve-search/issues/1211 
- https://github.com/cve-search/CveXplore/pull/339
- https://github.com/cve-search/CveXplore/pull/338
