### PR TITLE
fix(web): add server-side validations for /fetch_cve_data inputs

### DIFF
--- a/web/helpers/server_side_datatables.py
+++ b/web/helpers/server_side_datatables.py
@@ -4,6 +4,7 @@ server_side_datatables.py
 """
 
 from collections import namedtuple, defaultdict
+from lib.Config import Configuration
 
 
 class ServerSideDataTable(object):
@@ -136,7 +137,27 @@ class ServerSideDataTable(object):
 
         data_length = namedtuple("data_length", ["start", "length"])
 
-        data_length.start = int(self.request_values["start"])
-        data_length.length = int(self.request_values["length"])
+        try:
+            start = int(self.request_values.get("start", 0))
+            length = int(self.request_values.get("length", 50))
+        except (TypeError, ValueError):
+            raise ValueError("Invalid pagination parameters")
 
-        return data_length
+        if start < 0:
+            raise ValueError("Invalid pagination start parameter")
+
+        # Config-driven limit (trusted operator setting)
+        try:
+            config_limit = int(Configuration.getPageLength())
+        except Exception:
+            config_limit = 50
+
+        # Maximum page size aligned with DataTables UI configuration (default dropdown cap)
+        MAX_PAGE_SIZE = max(config_limit, 100)
+
+        if length < 1 or length > MAX_PAGE_SIZE:
+            raise ValueError("Invalid pagination length parameter")
+
+        result = data_length(start=start, length=length)
+
+        return result

--- a/web/helpers/server_side_datatables.py
+++ b/web/helpers/server_side_datatables.py
@@ -54,6 +54,17 @@ class ServerSideDataTable(object):
         Method to provision the necessary variables for the correct retrieval of the results from the MongoDB Database
         """
 
+        ALLOWED_COLUMNS = {
+            "blank",
+            "id",
+            "cvss",
+            "cvss3",
+            "cvss4",
+            "summary",
+            "lastModified",
+            "published",
+        }
+
         self.current_draw = int(self.request_values["draw"])
 
         self.data_length = self.__data_dimension()
@@ -62,12 +73,22 @@ class ServerSideDataTable(object):
             self.request_values
         )
 
-        self.sort = self.backend.datatables_data_order(self.ordering, self.columns)
-
         self.fields = defaultdict(int)
 
+        # Validate columns before they are used for sorting/filtering/projection
         for each in self.columns:
-            self.fields[self.columns[each]["data"]] = 1
+            field = self.columns[each]["data"]
+
+            if field not in ALLOWED_COLUMNS:
+                raise ValueError("Invalid column requested")
+
+            # Frontend-only synthetic column; not stored in MongoDB
+            if field == "blank":
+                continue
+
+            self.fields[field] = 1
+
+        self.sort = self.backend.datatables_data_order(self.ordering, self.columns)
 
         if len(self.sort) == 0:
             self.sort = None

--- a/web/home/views.py
+++ b/web/home/views.py
@@ -375,18 +375,24 @@ def fetch_cvedata():
     except TypeError:
         filter_params = defaultFilters
 
-    if filter_params == defaultFilters:
-        ssd = ServerSideDataTable(request=request, backend=app.dbh.connection)
-    else:
-        query_filters = generate_minimal_query(filter_params)
-        if len(query_filters) != 0:
-            ssd = ServerSideDataTable(
-                request=request,
-                backend=app.dbh.connection,
-                additional_filters=query_filters,
-            )
-        else:
+    try:
+        if filter_params == defaultFilters:
             ssd = ServerSideDataTable(request=request, backend=app.dbh.connection)
+        else:
+            query_filters = generate_minimal_query(filter_params)
+            if len(query_filters) != 0:
+                ssd = ServerSideDataTable(
+                    request=request,
+                    backend=app.dbh.connection,
+                    additional_filters=query_filters,
+                )
+            else:
+                ssd = ServerSideDataTable(request=request, backend=app.dbh.connection)
+    except ValueError as err:
+        return make_response(
+            jsonify(error=str(err)),
+            400,
+        )
 
     return_data = ssd.output_result()
 

--- a/web/home/views.py
+++ b/web/home/views.py
@@ -360,6 +360,14 @@ def get_filter():
 
 @home.route("/fetch_cve_data", methods=["POST"])
 def fetch_cvedata():
+    # Enforce endpoint constraints: this API only serves CVE data
+    retrieve = request.form.get("retrieve")
+    if retrieve != "cves":
+        return make_response(
+            jsonify(error="invalid retrieve parameter"),
+            400,
+        )
+
     try:
         filter_params = dict(json.loads(request.cookies.get("cve_filter")))
         if not validateFilter(filter_params):


### PR DESCRIPTION
This PR fixes an unauthenticated NoSQL injection vulnerability in `/fetch_cve_data`, which allowed arbitrary MongoDB collection access and exposure of sensitive data, including administrative password hashes.

It also introduces additional server-side validations to eliminate:

- arbitrary collection access via request parameters
- sensitive field exposure via projection manipulation
- regex/filter-based data extraction primitives
- pagination-based denial-of-service vectors

The endpoint now strictly enforces a CVE-only, schema-constrained, bounded query model while preserving DataTables functionality.

The endpoint previously trusted attacker-controlled request parameters to determine collection selection, field projection, sorting, and pagination behavior, enabling full database access. Part of these attacker-controlled parameters were reported in a related issue.

Fixes https://github.com/cve-search/cve-search/issues/1217

## Changes

### 1. Restrict `/fetch_cve_data` to CVE dataset
- Reject non-CVE values in the `retrieve` parameter, ensuring the endpoint only operates on the CVE collection
- Prevent arbitrary collection traversal via request input
- Returns HTTP 400 for invalid targets

### 2. Validate DataTables column projections and sorting in `ServerSideDataTable`
- Introduce allowlist-based validation for DataTables column fields, ensuring only expected CVE schema fields are queryable
- Prevent attacker-controlled fields from influencing MongoDB projection or sort operations
- Invalid or unexpected column definitions raise `ValueError`, handled at API layer as HTTP 400

### 3. Enforce pagination bounds in `ServerSideDataTable`
- Validate `start` and `length` parameters to prevent unbounded queries
- Reject negative offsets and excessive page sizes
- Maximum page size is derived from configuration (`[Webserver] PageLength`) with a safe UI-aligned baseline (`100`)
- Invalid values raise `ValueError`, handled at API layer as HTTP 400

## Validation

| Case | Before | After |
|------|--------|-------|
| Unauthorized collection access (`mgmt_users`) | ⚠️ `200 OK` (**confirmed data leak**) | ✅ `400 Bad Request` |
| Column injection (`password` field) | ⚠️ `200 OK` | ✅ `400 Bad Request` |
| Pagination overflow (`length=110`) | ⚠️ `200 OK` | ✅ `400 Bad Request` |
| Negative pagination (`start=-1000`) | 🛠️ `500 Internal Server Error` | ✅ `400 Bad Request` |
| Valid CVE request | ✅ `200 OK` (expected) | ✅ `200 OK` (unchanged) |