### PR TITLE
ci(tests): fix and simplify Build & Test workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'pip'
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.3.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,131 +9,48 @@ on:
       - master
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ '3.10' ]
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache pip
-      id: cache-pip
-      uses: actions/cache@v4
-      with:
-        # This path is specific to Ubuntu
-        # path: ~/.cache/pip
-        path: ${{ env.pythonLocation}}
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}_${{ env.pythonLocation}}_pip_v1_${{ matrix.python-version }}_${{ hashFiles('requirements.txt') }}_${{ hashFiles('requirements-dev.txt') }}
-    - name: Install dependencies
-      if: steps.cache-pip.outputs.cache-hit != 'true'
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-
   test:
-    needs: build
     runs-on: ubuntu-latest
+
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ '3.10' ]
-        mongodb-version: [ '4.4', '6.0', '8.0' ]
+        python-version: ['3.10']
+        mongodb-version: ['4.4', '6.0', '8.0']
 
     steps:
       - uses: actions/checkout@v4
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.3.0
-        with:
-          mongodb-version: ${{ matrix.mongodb-version }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip
-        id: cache-pip
-        uses: actions/cache@v4
+          cache: 'pip'
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
         with:
-          # This path is specific to Ubuntu
-          # path: ~/.cache/pip
-          path: ${{ env.pythonLocation}}
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}_${{ env.pythonLocation}}_pip_v1_${{ matrix.python-version }}_${{ hashFiles('requirements.txt') }}_${{ hashFiles('requirements-dev.txt') }}
-      - name: Test with pytest
+          mongodb-version: ${{ matrix.mongodb-version }}
+
+      - name: Install dependencies
         run: |
-          pytest --doctest-modules --junitxml=junit/test-results_${{ matrix.python-version }}_${{ matrix.mongodb-version }}.xml --cov-report=xml --cov-report=html --cov=./ test/unit
-      - name: Upload pytest test results
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: |
+          pytest \
+            --doctest-modules \
+            --junitxml=junit/test-results_${{ matrix.python-version }}_${{ matrix.mongodb-version }}.xml \
+            --cov=./ \
+            --cov-report=xml \
+            --cov-report=html \
+            test/unit
+
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pytest-results_${{ matrix.python-version }}_${{ matrix.mongodb-version }}
           path: junit/test-results_${{ matrix.python-version }}_${{ matrix.mongodb-version }}.xml
-        # Use always() to always run this step to publish test results when there are test failures
-#        if: ${{ always() }}
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v1
-#        with:
-#          file: junit/test-results_${{ matrix.python-version }}.xml
-#          flags: unittests
-#          env_vars: OS,PYTHON
-#          name: codecov-umbrella
-#          fail_ci_if_error: true
-#          verbose: true
-
-#  web_tests:
-#    needs: build
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Set up Python 3.10
-#        uses: actions/setup-python@v2
-#        with:
-#          python-version: '3.10'
-#      - name: Cache pip
-#        id: cache-pip
-#        uses: actions/cache@v2
-#        with:
-#          # This path is specific to Ubuntu
-#          # path: ~/.cache/pip
-#          path: ${{ env.pythonLocation}}
-#          # Look to see if there is a cache hit for the corresponding requirements file
-#          key: ${{ runner.os }}_${{ env.pythonLocation}}_pip_v1_3.10_${{ hashFiles('requirements.txt') }}_${{ hashFiles('requirements-dev.txt') }}
-#      - name: Install latest docker version
-#        run: |
-#          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-#          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-#          sudo apt-get update
-#          sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-#      - name: Clone Cve Search Docker and Run docker-compose
-#        if: github.event_name == 'push'
-#        run: |
-#          git clone https://github.com/cve-search/CVE-Search-Docker.git
-#          cd CVE-Search-Docker
-#          docker-compose build
-#          docker-compose up -d
-#          sleep 180
-#      - name: Clone Cve Search Docker and Run docker-compose
-#        if: github.event_name == 'pull_request'
-#        env:
-#          PR_REPO_OWNER: ${{ github.actor }}
-#          PR_REPO_NAME: /cve-search
-#          PR_BRANCH: ${{ github.head_ref }}
-#        run: |
-#          git clone https://github.com/cve-search/CVE-Search-Docker.git
-#          cd CVE-Search-Docker
-#          docker-compose build --build-arg REPO=$PR_REPO_OWNER$PR_REPO_NAME --build-arg BRANCH=$PR_BRANCH
-#          docker-compose up -d
-#          sleep 180
-#      - name: Test with pytest
-#        run: |
-#          pytest --doctest-modules --junitxml=junit/test-results_web_${{ matrix.python-version }}.xml test/web/
-#      - name: Upload pytest test results
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: pytest-results_web_${{ matrix.python-version }}
-#          path: junit/test-results_web_${{ matrix.python-version }}.xml


### PR DESCRIPTION
This PR fixes and simplifies the GitHub Actions CI pipeline for the test suite by consolidating the previously split Build and Test jobs into a single matrix-based workflow.

The change resolves a CI failure where `pytest` was not available in the test job due to dependencies being installed in a separate job context, which does not share runtime state.

The updated workflow ensures a consistent and reproducible testing environment across all supported Python and MongoDB versions.